### PR TITLE
Include valid cloud event in subscription validation

### DIFF
--- a/src/Events.Functions/SubscriptionValidation.cs
+++ b/src/Events.Functions/SubscriptionValidation.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+
 using Altinn.Platform.Events.Functions.Configuration;
 using Altinn.Platform.Events.Functions.Models;
 using Altinn.Platform.Events.Functions.Services.Interfaces;
 using Altinn.Platform.Events.Models;
+
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -54,9 +56,14 @@ namespace Altinn.Platform.Events.Functions
             cloudEventEnvelope.Consumer = subscription.Consumer;
             cloudEventEnvelope.Endpoint = subscription.EndPoint;
             cloudEventEnvelope.SubscriptionId = subscription.Id;
-            cloudEventEnvelope.CloudEvent = new CloudEvent();
-            cloudEventEnvelope.CloudEvent.Source = new Uri(_platformSettings.ApiEventsEndpoint + "subscriptions/" + subscription.Id);
-            cloudEventEnvelope.CloudEvent.Type = "platform.events.validatesubscription";
+            cloudEventEnvelope.CloudEvent = new CloudEvent
+            {
+                Id = Guid.NewGuid().ToString(),
+                Source = new Uri(_platformSettings.ApiEventsEndpoint + "subscriptions/" + subscription.Id),
+                Type = "platform.events.validatesubscription",
+                SpecVersion = "1.0"
+            };
+
             return cloudEventEnvelope;
         }
     }


### PR DESCRIPTION
## Related Issue(s)
- #27

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
~~- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green
