### PR TITLE
Feature/25 fix subscription source filter to match on URL path segments

### DIFF
--- a/src/Events/Services/SubscriptionService.cs
+++ b/src/Events/Services/SubscriptionService.cs
@@ -50,7 +50,7 @@ namespace Altinn.Platform.Events.Services
         {
             List<Subscription> searchresult = await _repository.GetSubscriptionsByConsumer("/org/%", false);
             return searchresult.Where(s =>
-                IsURIPathSegmentsMatching(source, s.SourceFilter) &&
+                CheckIfSourceURIPathSegmentsMatch(source, s.SourceFilter) &&
                 (s.SubjectFilter == null || s.SubjectFilter.Equals(subject)) &&
                 (s.TypeFilter == null || s.TypeFilter.Equals(type))).ToList();
         }
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Events.Services
             await _repository.SetValidSubscription(id);
         }
 
-        private static bool IsURIPathSegmentsMatching(string source, Uri sourceFilter)
+        private static bool CheckIfSourceURIPathSegmentsMatch(string source, Uri sourceFilter)
         {
             Uri sourceUri;
 

--- a/src/Events/Services/SubscriptionService.cs
+++ b/src/Events/Services/SubscriptionService.cs
@@ -77,11 +77,7 @@ namespace Altinn.Platform.Events.Services
         {
             Uri sourceUri;
 
-            try
-            {
-                sourceUri = new Uri(source);
-            }
-            catch
+            if (!Uri.TryCreate(source, UriKind.Absolute, out sourceUri))
             {
                 return false;
             }

--- a/test/Altinn.Platform.Events.Tests/Data/subscriptions/1.json
+++ b/test/Altinn.Platform.Events.Tests/Data/subscriptions/1.json
@@ -61,5 +61,14 @@
     "Typefilter": "app.instance.process.started",
     "EndPoint": "https://www.ttd.no/webhook",
     "Time": "2020-10-13T11:50:29.463221+00"
+  },
+  {
+    "Id": "8",
+    "Sourcefilter": "https://ttd.apps.altinn.no/ttd/endring-av-navn",
+    "Consumer": "/org/ttd",
+    "CreatedBy": "/org/ttd",
+    "Typefilter": "app.instance.process.completed",
+    "EndPoint": "https://www.ttd.no/webhook",
+    "Time": "2020-10-13T11:50:29.463221+00"
   }
 ]

--- a/test/Altinn.Platform.Events.Tests/Data/subscriptions/1.json
+++ b/test/Altinn.Platform.Events.Tests/Data/subscriptions/1.json
@@ -70,5 +70,14 @@
     "Typefilter": "app.instance.process.completed",
     "EndPoint": "https://www.ttd.no/webhook",
     "Time": "2020-10-13T11:50:29.463221+00"
+  },
+  {
+    "Id": "9",
+    "Sourcefilter": "ftp://ttd.apps.altinn.no/ttd/endring-av-navn-v2",
+    "Consumer": "/org/ttd",
+    "CreatedBy": "/org/ttd",
+    "Typefilter": "app.instance.process.completed",
+    "EndPoint": "https://www.ttd.no/webhook",
+    "Time": "2020-10-13T11:50:29.463221+00"
   }
 ]

--- a/test/Altinn.Platform.Events.Tests/TestingServices/SubscriptionServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/SubscriptionServiceTest.cs
@@ -89,9 +89,20 @@ namespace Tests.TestingServices
 
             SubscriptionService subscriptionService = new SubscriptionService(_repoMock.Object, new QueueServiceMock());
 
-            await subscriptionService.GetOrgSubscriptions("source", "subject", "type");
+            await subscriptionService.GetOrgSubscriptions("source", "party/1337", null);
 
             _repoMock.VerifyAll();
+        }
+
+        [Fact]
+        public async Task GetOrgSubscriptions_InvalidSourceUri()
+        {
+            SubscriptionService subscriptionService = new SubscriptionService(new SubscriptionRepositoryMock(), new QueueServiceMock());
+            List<Subscription> result = await subscriptionService.GetOrgSubscriptions(
+                "ttd/endring-av-navn-v2",
+                "/party/1337",
+                "app.instance.process.completed");
+            Assert.True(result.Count == 0);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The subscription source filter will now only match if the URL path
segments match, instead of comparing two URLs as strings.

Example:
Filter: https://host.com/a/b
will no longer match events with source: https://host.com/a/bc
but will still match with: https://host.com/a/b/instance/1

## Related Issue(s)
- #25 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
