### PR TITLE
roll back Microsoft.IdentityModel.Tokens to 6.23.0

### DIFF
--- a/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
+++ b/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
@@ -14,7 +14,8 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <!--Waiting on workaround for QueueProcessor before upgrade to Microsoft.Azure.WebJobs.Extensions.Storage.Queue 5.0.0-->
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.23.1" />
+    <!-- Do not upgrade IdentityModel.Tokens to 6.23.1, breaks solution -->
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.23.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
   </ItemGroup>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
V 6.23.1 of the package causes function to fail during token generation. Must investigate cause of error and request fix from microsoft before patching this library. 

## Related Issue(s)
- #{issue number}
N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
