### PR TITLE
Transfer validated value into subscription object

### DIFF
--- a/src/Events/Repository/SubscriptionRepository.cs
+++ b/src/Events/Repository/SubscriptionRepository.cs
@@ -192,7 +192,8 @@ namespace Altinn.Platform.Events.Repository
                 Consumer = reader.GetValue<string>("consumer"),
                 EndPoint = new Uri(reader.GetValue<string>("endpointurl")),
                 CreatedBy = reader.GetValue<string>("createdby"),
-                Created = reader.GetValue<DateTime>("time").ToUniversalTime()
+                Created = reader.GetValue<DateTime>("time").ToUniversalTime(),
+                Validated = reader.GetValue<bool>("validated")
             };
             return subscription;
         }


### PR DESCRIPTION
## Description
When adding the property Validated to Subscription I forgot to ensure the property were set when reading from the result set after DB call.

## Related Issue(s)
- #129 