### PR TITLE
Block Microsoft.IdentityModel.Tokens in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>Altinn/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["Microsoft.IdentityModel.Tokens"],
+      "allowedVersions": "<=6.23.0"
+    }
   ]
 }


### PR DESCRIPTION
Freeze Microsoft.IdentityModel.Tokens at version 6.23.0 until we have confirmed that newer versions don't break.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


## Related Issue(s)
- #153

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
