### PR TITLE
Check for dateTime.Kind specified in query params

### DIFF
--- a/src/Events/Controllers/AppEventsController.cs
+++ b/src/Events/Controllers/AppEventsController.cs
@@ -215,7 +215,7 @@ namespace Altinn.Platform.Events.Controllers
             }
         }
 
-        private void ValidateQueryParams(string after, DateTime? from, DateTime? to, int size)
+        private static void ValidateQueryParams(string after, DateTime? from, DateTime? to, int size)
         {
             if (string.IsNullOrEmpty(after) && from == null)
             {

--- a/src/Events/Controllers/AppEventsController.cs
+++ b/src/Events/Controllers/AppEventsController.cs
@@ -225,7 +225,7 @@ namespace Altinn.Platform.Events.Controllers
 
             if (to != null && to.Value.Kind == DateTimeKind.Unspecified)
             {
-                return (false, "To must specify timezone. E.g. 2022-07-07T11:00:53.3917Z for UTC");
+                return (false, "The 'To' parameter must specify timezone. E.g. 2022-07-07T11:00:53.3917Z for UTC");
             }
 
             if (size < 1)

--- a/src/Events/Controllers/AppEventsController.cs
+++ b/src/Events/Controllers/AppEventsController.cs
@@ -215,12 +215,12 @@ namespace Altinn.Platform.Events.Controllers
         {
             if (string.IsNullOrEmpty(after) && from == null)
             {
-                return (false, "From or after must be defined.");
+                return (false, "The 'From' or 'After' parameter must be defined.");
             }
 
             if (from != null && from.Value.Kind == DateTimeKind.Unspecified)
             {
-                return (false, "From must specify timezone. E.g. 2022-07-07T11:00:53.3917Z for UTC");
+                return (false, "The 'From' parameter must specify timezone. E.g. 2022-07-07T11:00:53.3917Z for UTC");
             }
 
             if (to != null && to.Value.Kind == DateTimeKind.Unspecified)
@@ -230,7 +230,7 @@ namespace Altinn.Platform.Events.Controllers
 
             if (size < 1)
             {
-                return (false, "Size must be a number larger that 0.");
+                return (false, "The 'Size' parameter must be a number larger that 0.");
             }
 
             return (true, null);

--- a/src/Events/Controllers/AppEventsController.cs
+++ b/src/Events/Controllers/AppEventsController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -133,14 +133,13 @@ namespace Altinn.Platform.Events.Controllers
                 return StatusCode(401, "Only orgs can call this api");
             }
 
-            if (string.IsNullOrEmpty(after) && from == null)
+            try
             {
-                return Problem("From or after must be defined.", null, 400);
+                ValidateQueryParams(after, from, to, size);
             }
-
-            if (size < 1)
+            catch (ArgumentException e)
             {
-                return Problem("Size must be a number larger that 0.", null, 400);
+                return Problem(e.Message, null, 400);
             }
 
             var source = new List<string> { $"%{org}/{app}%" };
@@ -190,14 +189,13 @@ namespace Altinn.Platform.Events.Controllers
             [FromQuery] List<string> type,
             [FromQuery] int size = 50)
         {
-            if (string.IsNullOrEmpty(after) && from == null)
+            try
             {
-                return Problem("From or after must be defined.", null, 400);
+                ValidateQueryParams(after, from, to, size);
             }
-
-            if (size < 1)
+            catch (ArgumentException e)
             {
-                return Problem("Size must be a number larger that 0.", null, 400);
+                return Problem(e.Message, null, 400);
             }
 
             if (string.IsNullOrEmpty(person) && string.IsNullOrEmpty(unit) && party <= 0)
@@ -214,6 +212,29 @@ namespace Altinn.Platform.Events.Controllers
             catch (PlatformHttpException e)
             {
                 return HandlePlatformHttpException(e);
+            }
+        }
+
+        private void ValidateQueryParams(string after, DateTime? from, DateTime? to, int size)
+        {
+            if (string.IsNullOrEmpty(after) && from == null)
+            {
+                throw new ArgumentException("From or after must be defined.");
+            }
+
+            if (from != null && from.Value.Kind == DateTimeKind.Unspecified)
+            {
+                throw new ArgumentException("From must specify timezone. E.g. 2022-07-07T11:00:53.3917Z for UTC");
+            }
+
+            if (to != null && to.Value.Kind == DateTimeKind.Unspecified)
+            {
+                throw new ArgumentException("To must specify timezone. E.g. 2022-07-07T11:00:53.3917Z for UTC");
+            }
+
+            if (size < 1)
+            {
+                throw new ArgumentException("Size must be a number larger that 0.");
             }
         }
 

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppEventsControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppEventsControllerTests.cs
@@ -262,7 +262,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             public async void GetForOrg_MissingRequiredFromOrAfterParam_ReturnsBadRequest()
             {
                 // Arrange
-                string expected = "From or after must be defined.";
+                string expected = "The 'From' or 'After' parameter must be defined.";
 
                 string requestUri = $"{BasePath}/app/ttd/endring-av-navn-v2?size=5";
                 HttpClient client = GetTestClient(new Mock<IAppEventsService>().Object);
@@ -293,7 +293,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app/ttd/endring-av-navn-v2?from=2020-01-01Z&size=-5";
-                string expected = "Size must be a number larger that 0.";
+                string expected = "The 'Size' parameter must be a number larger that 0.";
 
                 HttpClient client = GetTestClient(new Mock<IAppEventsService>().Object);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd"));
@@ -452,7 +452,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-                Assert.StartsWith("From must specify timezone.", actual.Detail);
+                Assert.StartsWith("The 'From' parameter must specify timezone.", actual.Detail);
             }
 
             /// <summary>
@@ -482,7 +482,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-                Assert.StartsWith("To must specify timezone.", actual.Detail);
+                Assert.StartsWith("The 'To' parameter must specify timezone.", actual.Detail);
             }
 
             /// <summary>
@@ -497,7 +497,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             public async void GetForParty_MissingRequiredQueryParam_ReturnsBadRequest()
             {
                 // Arrange   
-                string expected = "From or after must be defined.";
+                string expected = "The 'From' or 'After' parameter must be defined.";
 
                 string requestUri = $"{BasePath}/app/party?size=5";
                 HttpClient client = GetTestClient(new Mock<IAppEventsService>().Object);
@@ -528,7 +528,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app/party?from=2020-01-01Z&size=-5";
-                string expected = "Size must be a number larger that 0.";
+                string expected = "The 'Size' parameter must be a number larger that 0.";
 
                 HttpClient client = GetTestClient(new Mock<IAppEventsService>().Object);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));
@@ -814,7 +814,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-                Assert.StartsWith("From must specify timezone.", actual.Detail);
+                Assert.StartsWith("The 'From' parameter must specify timezone.", actual.Detail);
             }
 
             /// <summary>
@@ -844,7 +844,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-                Assert.StartsWith("To must specify timezone.", actual.Detail);
+                Assert.StartsWith("The 'To' parameter must specify timezone.", actual.Detail);
             }
 
             private HttpClient GetTestClient(IAppEventsService eventsService)

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppEventsControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppEventsControllerTests.cs
@@ -485,7 +485,6 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 Assert.StartsWith("To must specify timezone.", actual.Detail);
             }
 
-
             /// <summary>
             /// Scenario:
             ///   Get events without defined after or from in query.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Validating DateTime-objects in controller to avoid exception being thrown by database.
- Moved validation of common query parameters to a private method that throws an exception. Could be middleware instead or set up as a Guard I guess. Open for suggestions here to avoid duplication of the validation logic. 

## Related Issue(s)
- #28

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
~~- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green
