### PR TITLE
Store incoming cloud events in events-registration queue

### DIFF
--- a/src/Events.Functions/Clients/EventsClient.cs
+++ b/src/Events.Functions/Clients/EventsClient.cs
@@ -110,7 +110,7 @@ namespace Altinn.Platform.Events.Functions.Clients
         {
             StringContent httpContent = new(JsonSerializer.Serialize(cloudEvent), Encoding.UTF8, "application/json");
 
-            string endpointUrl = "outbound";
+            string endpointUrl = "push";
 
             var accessToken = await GenerateAccessToken();
 

--- a/src/Events.Functions/Clients/EventsClient.cs
+++ b/src/Events.Functions/Clients/EventsClient.cs
@@ -110,7 +110,7 @@ namespace Altinn.Platform.Events.Functions.Clients
         {
             StringContent httpContent = new(JsonSerializer.Serialize(cloudEvent), Encoding.UTF8, "application/json");
 
-            string endpointUrl = "push";
+            string endpointUrl = "outbound";
 
             var accessToken = await GenerateAccessToken();
 

--- a/src/Events/Altinn.Platform.Events.csproj
+++ b/src/Events/Altinn.Platform.Events.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
     <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
     <PackageReference Include="Yuniql.PostgreSql" Version="1.3.15" />
   </ItemGroup>

--- a/src/Events/Clients/Interfaces/IEventsQueueClient.cs
+++ b/src/Events/Clients/Interfaces/IEventsQueueClient.cs
@@ -9,6 +9,13 @@ namespace Altinn.Platform.Events.Clients.Interfaces
     public interface IEventsQueueClient
     {
         /// <summary>
+        /// Enqueues the provided content to the registration queue
+        /// </summary>
+        /// <param name="content">The content to push to the queue in string format</param>
+        /// <returns>Returns a queue receipt</returns>
+        public Task<QueuePostReceipt> EnqueueRegistration(string content);
+
+        /// <summary>
         /// Enqueues the provided content to the inbound queue
         /// </summary>
         /// <param name="content">The content to push to the queue in string format</param>

--- a/src/Events/Configuration/QueueStorageSettings.cs
+++ b/src/Events/Configuration/QueueStorageSettings.cs
@@ -13,6 +13,11 @@ namespace Altinn.Platform.Events.Configuration
         public string ConnectionString { get; set; }
 
         /// <summary>
+        /// Name of the queue to push incoming events to, before persisting to db.
+        /// </summary>
+        public string RegistrationQueueName { get; set; }
+
+        /// <summary>
         /// Name of the queue to push incoming events to, after persisting to db.
         /// </summary>
         public string InboundQueueName { get; set; }

--- a/src/Events/Controllers/AppController.cs
+++ b/src/Events/Controllers/AppController.cs
@@ -85,7 +85,7 @@ namespace Altinn.Platform.Events.Controllers
 
             try
             {
-                string cloudEventId = await _eventsService.PostRegistration(_mapper.Map<CloudEvent>(cloudEvent));
+                string cloudEventId = await _eventsService.RegisterNew(_mapper.Map<CloudEvent>(cloudEvent));
                 return Created(cloudEvent.Subject, cloudEventId);
             }
             catch (Exception e)

--- a/src/Events/Controllers/AppController.cs
+++ b/src/Events/Controllers/AppController.cs
@@ -68,7 +68,7 @@ namespace Altinn.Platform.Events.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<string>> Post([FromBody] CloudEventRequestModel cloudEvent)
         {
-            if (string.IsNullOrEmpty(cloudEvent.Source.OriginalString) ||
+            if (string.IsNullOrEmpty(cloudEvent.Source?.OriginalString) ||
                 string.IsNullOrEmpty(cloudEvent.SpecVersion) ||
                 string.IsNullOrEmpty(cloudEvent.Type) || string.IsNullOrEmpty(cloudEvent.Subject))
             {

--- a/src/Events/Controllers/AppController.cs
+++ b/src/Events/Controllers/AppController.cs
@@ -68,8 +68,9 @@ namespace Altinn.Platform.Events.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<string>> Post([FromBody] CloudEventRequestModel cloudEvent)
         {
-            if (string.IsNullOrEmpty(cloudEvent.Source.OriginalString) || string.IsNullOrEmpty(cloudEvent.SpecVersion) ||
-            string.IsNullOrEmpty(cloudEvent.Type) || string.IsNullOrEmpty(cloudEvent.Subject))
+            if (string.IsNullOrEmpty(cloudEvent.Source.OriginalString) ||
+                string.IsNullOrEmpty(cloudEvent.SpecVersion) ||
+                string.IsNullOrEmpty(cloudEvent.Type) || string.IsNullOrEmpty(cloudEvent.Subject))
             {
                 return Problem("Missing parameter values: source, subject, type, id or time cannot be null", null, 400);
             }
@@ -83,13 +84,14 @@ namespace Altinn.Platform.Events.Controllers
 
             try
             {
-                string cloudEventId = await _eventsService.SaveAndPostInbound(_mapper.Map<CloudEvent>(cloudEvent));
+                string cloudEventId = await _eventsService.PostRegistration(_mapper.Map<CloudEvent>(cloudEvent));
+                _logger.LogInformation("Cloud Event successfully registered with id: {cloudEventId}", cloudEventId);
                 return Created(cloudEvent.Subject, cloudEventId);
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Unable to save cloud event to storage.");
-                return StatusCode(500, $"Unable to save cloud event to storage.");
+                _logger.LogError(e, "Unable to register cloud event in queue.");
+                return StatusCode(500, $"Unable to register cloud event in queue.");
             }
         }
 

--- a/src/Events/Controllers/AppController.cs
+++ b/src/Events/Controllers/AppController.cs
@@ -70,7 +70,8 @@ namespace Altinn.Platform.Events.Controllers
         {
             if (string.IsNullOrEmpty(cloudEvent.Source?.OriginalString) ||
                 string.IsNullOrEmpty(cloudEvent.SpecVersion) ||
-                string.IsNullOrEmpty(cloudEvent.Type) || string.IsNullOrEmpty(cloudEvent.Subject))
+                string.IsNullOrEmpty(cloudEvent.Type) || 
+                string.IsNullOrEmpty(cloudEvent.Subject))
             {
                 return Problem("Missing parameter values: source, subject, type, id or time cannot be null", null, 400);
             }
@@ -85,7 +86,6 @@ namespace Altinn.Platform.Events.Controllers
             try
             {
                 string cloudEventId = await _eventsService.PostRegistration(_mapper.Map<CloudEvent>(cloudEvent));
-                _logger.LogInformation("Cloud Event successfully registered with id: {cloudEventId}", cloudEventId);
                 return Created(cloudEvent.Subject, cloudEventId);
             }
             catch (Exception e)

--- a/src/Events/Migration/v0.15/01-setup-functions.sql
+++ b/src/Events/Migration/v0.15/01-setup-functions.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION events.inserteventV2(
+CREATE OR REPLACE FUNCTION events.insertevent(
 	id character varying,
 	source character varying,
 	subject character varying,

--- a/src/Events/Migration/v0.15/01-setup-functions.sql
+++ b/src/Events/Migration/v0.15/01-setup-functions.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION events.insertevent(
 	source character varying,
 	subject character varying,
 	type character varying,
-	time timestamptz,
+	"time" timestamptz,
 	cloudevent INOUT text)
     LANGUAGE 'plpgsql'
     

--- a/src/Events/Migration/v0.15/01-setup-functions.sql
+++ b/src/Events/Migration/v0.15/01-setup-functions.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION events.inserteventV2(
+	id character varying,
+	source character varying,
+	subject character varying,
+	type character varying,
+	time timestamptz,
+	cloudevent INOUT text)
+    LANGUAGE 'plpgsql'
+    
+AS $BODY$
+	DECLARE storedCloudEvent text;
+
+  BEGIN
+	INSERT INTO events.events(id, source, subject, type, "time", cloudevent)
+	  VALUES ($1, $2, $3, $4, $5, $6);
+
+	SELECT storedCloudEvent
+	INTO cloudevent;
+  END;
+
+$BODY$;

--- a/src/Events/Repository/CloudEventRepository.cs
+++ b/src/Events/Repository/CloudEventRepository.cs
@@ -20,7 +20,7 @@ namespace Altinn.Platform.Events.Repository
     [ExcludeFromCodeCoverage]
     public class CloudEventRepository : ICloudEventRepository
     {
-        private readonly string insertEventSql = "select events.inserteventV2(@id, @source, @subject, @type, @time, @cloudevent)";
+        private readonly string insertEventSql = "select events.insertevent(@id, @source, @subject, @type, @time, @cloudevent)";
         private readonly string getEventSql = "select events.get(@_subject, @_after, @_from, @_to, @_type, @_source, @_size)";
         private readonly string _connectionString;
 

--- a/src/Events/Repository/CloudEventRepository.cs
+++ b/src/Events/Repository/CloudEventRepository.cs
@@ -20,7 +20,7 @@ namespace Altinn.Platform.Events.Repository
     [ExcludeFromCodeCoverage]
     public class CloudEventRepository : ICloudEventRepository
     {
-        private readonly string insertEventSql = "select events.insertevent(@id, @source, @subject, @type, @cloudevent)";
+        private readonly string insertEventSql = "select events.inserteventV2(@id, @source, @subject, @type, @time, @cloudevent)";
         private readonly string getEventSql = "select events.get(@_subject, @_after, @_from, @_to, @_type, @_source, @_size)";
         private readonly string _connectionString;
 
@@ -45,6 +45,7 @@ namespace Altinn.Platform.Events.Repository
             pgcom.Parameters.AddWithValue("source", cloudEvent.Source.OriginalString);
             pgcom.Parameters.AddWithValue("subject", cloudEvent.Subject);
             pgcom.Parameters.AddWithValue("type", cloudEvent.Type);
+            pgcom.Parameters.AddWithValue("time", cloudEvent.Time.Value.ToUniversalTime());
             pgcom.Parameters.Add(new NpgsqlParameter("cloudevent", cloudEvent.Serialize()) { Direction = System.Data.ParameterDirection.InputOutput });
 
             await pgcom.ExecuteNonQueryAsync();

--- a/src/Events/Services/EventsService.cs
+++ b/src/Events/Services/EventsService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/src/Events/Services/EventsService.cs
+++ b/src/Events/Services/EventsService.cs
@@ -64,7 +64,7 @@ namespace Altinn.Platform.Events.Services
         }
 
         /// <inheritdoc/>
-        public async Task<string> PostRegistration(CloudEvent cloudEvent)
+        public async Task<string> RegisterNew(CloudEvent cloudEvent)
         {
             cloudEvent.Id = Guid.NewGuid().ToString();
             cloudEvent.Time ??= DateTime.UtcNow;
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Events.Services
 
             if (!receipt.Success)
             {
-                _logger.LogError(receipt.Exception, "// EventsService // PostRegistration // Failed to send cloudEventId {EventId} to queue.", cloudEvent.Id);
+                _logger.LogError(receipt.Exception, "// EventsService // RegisterNew // Failed to send cloudEventId {EventId} to queue.", cloudEvent.Id);
             }
 
             return cloudEvent.Id;

--- a/src/Events/Services/EventsService.cs
+++ b/src/Events/Services/EventsService.cs
@@ -74,6 +74,7 @@ namespace Altinn.Platform.Events.Services
             if (!receipt.Success)
             {
                 _logger.LogError(receipt.Exception, "// EventsService // RegisterNew // Failed to send cloudEventId {EventId} to queue.", cloudEvent.Id);
+                throw receipt.Exception;
             }
 
             return cloudEvent.Id;

--- a/src/Events/Services/EventsService.cs
+++ b/src/Events/Services/EventsService.cs
@@ -68,7 +68,7 @@ namespace Altinn.Platform.Events.Services
         public async Task<string> PostRegistration(CloudEvent cloudEvent)
         {
             cloudEvent.Id = Guid.NewGuid().ToString();
-            cloudEvent.Time = DateTime.UtcNow; // assign timestamp on initial receipt
+            cloudEvent.Time ??= DateTime.UtcNow;
 
             QueuePostReceipt receipt = await _queueClient.EnqueueRegistration(JsonSerializer.Serialize(cloudEvent));
 

--- a/src/Events/Services/Interfaces/IEventsService.cs
+++ b/src/Events/Services/Interfaces/IEventsService.cs
@@ -20,22 +20,19 @@ namespace Altinn.Platform.Events.Services.Interfaces
         Task<string> Save(CloudEvent cloudEvent);
 
         /// <summary>
+        /// Push cloud event to registration queue.
+        /// </summary>
+        /// <param name="cloudEvent">The cloudEvent to be queued</param>
+        /// <returns>Id for the queued event</returns>
+        Task<string> PostRegistration(CloudEvent cloudEvent);
+
+        /// <summary>
         /// Push cloud event to inbound queue.
         /// Should only be attempted after saving to persistent storage. 
         /// </summary>
         /// <param name="cloudEvent">The cloudEvent to be queued</param>
         /// <returns>Id for the queued event</returns>
         Task<string> PostInbound(CloudEvent cloudEvent);
-
-        /// <summary>
-        /// Save a cloud event to persistent storage and
-        /// pushes to Inbound events queue in one operation.
-        /// Id will be assigned a new guid in string format.
-        /// </summary>
-        /// <param name="cloudEvent">The cloudEvent to be stored</param>
-        /// <returns>Id for the cloudEvent in persistent storage</returns>
-        [Obsolete("This function has been split in two and will be removed soon.")]
-        Task<string> SaveAndPostInbound(CloudEvent cloudEvent);
 
         /// <summary>
         /// Gets list of cloud events based on query params

--- a/src/Events/Services/Interfaces/IEventsService.cs
+++ b/src/Events/Services/Interfaces/IEventsService.cs
@@ -22,6 +22,12 @@ namespace Altinn.Platform.Events.Services.Interfaces
         /// <summary>
         /// Push cloud event to registration queue.
         /// </summary>
+        /// <remarks>
+        /// "time" is an optional Cloud Event property, according to the official spec.
+        /// From the spec docs:
+        ///   https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#notational-conventions
+        ///   As an Intermediary, we SHOULD forward OPTIONAL attributes
+        /// </remarks>
         /// <param name="cloudEvent">The cloudEvent to be queued</param>
         /// <returns>Id for the queued event</returns>
         Task<string> PostRegistration(CloudEvent cloudEvent);

--- a/src/Events/Services/Interfaces/IEventsService.cs
+++ b/src/Events/Services/Interfaces/IEventsService.cs
@@ -20,7 +20,7 @@ namespace Altinn.Platform.Events.Services.Interfaces
         Task<string> Save(CloudEvent cloudEvent);
 
         /// <summary>
-        /// Push cloud event to registration queue.
+        /// Assign Id and Time values and post cloud event to registration queue.
         /// </summary>
         /// <remarks>
         /// "time" is an optional Cloud Event property, according to the official spec.
@@ -30,7 +30,7 @@ namespace Altinn.Platform.Events.Services.Interfaces
         /// </remarks>
         /// <param name="cloudEvent">The cloudEvent to be queued</param>
         /// <returns>Id for the queued event</returns>
-        Task<string> PostRegistration(CloudEvent cloudEvent);
+        Task<string> RegisterNew(CloudEvent cloudEvent);
 
         /// <summary>
         /// Push cloud event to inbound queue.

--- a/src/Events/appsettings.json
+++ b/src/Events/appsettings.json
@@ -13,6 +13,7 @@
     "JwtCookieName": "AltinnStudioRuntime"
   },
   "QueueStorageSettings": {
+    "RegistrationQueueName": "events-registration",
     "InboundQueueName": "events-inbound",
     "OutboundQueueName": "events-outbound",
     "ValidationQueueName": "subscription-validation",

--- a/test/Altinn.Platform.Events.Tests/Mocks/CloudEventRepositoryMock.cs
+++ b/test/Altinn.Platform.Events.Tests/Mocks/CloudEventRepositoryMock.cs
@@ -27,8 +27,6 @@ namespace Altinn.Platform.Events.Tests.Mocks
         /// <inheritdoc/>
         public Task<CloudEvent> Create(CloudEvent cloudEvent)
         {
-            cloudEvent.Time = DateTime.UtcNow; // check the format here! goal 2021-02-12 09:35:20.050893+01
-            
             return Task.FromResult(cloudEvent);
         }
 

--- a/test/Altinn.Platform.Events.Tests/Mocks/EventsQueueClientMock.cs
+++ b/test/Altinn.Platform.Events.Tests/Mocks/EventsQueueClientMock.cs
@@ -18,6 +18,16 @@ namespace Altinn.Platform.Events.Tests.Mocks
         /// </summary>
         public Dictionary<string, List<CloudEventEnvelope>> OutboundQueue { get; set; }
 
+        public Task<QueuePostReceipt> EnqueueRegistration(string content)
+        {
+            return Task.FromResult(new QueuePostReceipt { Success = true });
+        }
+
+        public Task<QueuePostReceipt> EnqueueInbound(string content)
+        {
+            return Task.FromResult(new QueuePostReceipt { Success = true });
+        }
+
         public Task<QueuePostReceipt> EnqueueOutbound(string content)
         {
             CloudEventEnvelope cloudEventEnvelope = JsonSerializer.Deserialize<CloudEventEnvelope>(content);
@@ -29,11 +39,6 @@ namespace Altinn.Platform.Events.Tests.Mocks
 
             OutboundQueue[cloudEventEnvelope.CloudEvent.Id].Add(cloudEventEnvelope);
 
-            return Task.FromResult(new QueuePostReceipt { Success = true });
-        }
-
-        public Task<QueuePostReceipt> EnqueueInbound(string content)
-        {
             return Task.FromResult(new QueuePostReceipt { Success = true });
         }
 

--- a/test/Altinn.Platform.Events.Tests/Mocks/EventsServiceMock.cs
+++ b/test/Altinn.Platform.Events.Tests/Mocks/EventsServiceMock.cs
@@ -95,7 +95,7 @@ namespace Altinn.Platform.Events.Tests.Mocks
             throw new NotImplementedException();
         }
 
-        public Task<string> PostRegistration(CloudEvent cloudEvent)
+        public Task<string> RegisterNew(CloudEvent cloudEvent)
         {
             throw new NotImplementedException();
         }

--- a/test/Altinn.Platform.Events.Tests/Mocks/EventsServiceMock.cs
+++ b/test/Altinn.Platform.Events.Tests/Mocks/EventsServiceMock.cs
@@ -95,6 +95,11 @@ namespace Altinn.Platform.Events.Tests.Mocks
             throw new NotImplementedException();
         }
 
+        public Task<string> PostRegistration(CloudEvent cloudEvent)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<string> PostInbound(CloudEvent cloudEvent)
         {
             throw new NotImplementedException();

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
@@ -74,7 +74,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 CloudEventRequestModel cloudEvent = GetCloudEventRequest();
 
                 Mock<IEventsService> eventsService = new Mock<IEventsService>();
-                eventsService.Setup(s => s.PostRegistration(It.IsAny<CloudEvent>())).ReturnsAsync(responseId);
+                eventsService.Setup(s => s.RegisterNew(It.IsAny<CloudEvent>())).ReturnsAsync(responseId);
 
                 HttpClient client = GetTestClient(eventsService.Object);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));
@@ -112,7 +112,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 CloudEventRequestModel cloudEvent = GetCloudEventRequest();
 
                 Mock<IEventsService> eventsService = new Mock<IEventsService>();
-                eventsService.Setup(s => s.PostRegistration(It.IsAny<CloudEvent>())).ReturnsAsync(responseId);
+                eventsService.Setup(s => s.RegisterNew(It.IsAny<CloudEvent>())).ReturnsAsync(responseId);
 
                 HttpClient client = GetTestClient(eventsService.Object);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));
@@ -246,7 +246,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 string requestUri = $"{BasePath}/app";
                 CloudEventRequestModel cloudEvent = GetCloudEventRequest();
                 Mock<IEventsService> eventsService = new Mock<IEventsService>();
-                eventsService.Setup(er => er.PostRegistration(It.IsAny<CloudEvent>())).Throws(new Exception());
+                eventsService.Setup(er => er.RegisterNew(It.IsAny<CloudEvent>())).Throws(new Exception());
                 HttpClient client = GetTestClient(eventsService.Object);
 
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
@@ -74,7 +74,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 CloudEventRequestModel cloudEvent = GetCloudEventRequest();
 
                 Mock<IEventsService> eventsService = new Mock<IEventsService>();
-                eventsService.Setup(s => s.SaveAndPostInbound(It.IsAny<CloudEvent>())).ReturnsAsync(responseId);
+                eventsService.Setup(s => s.PostRegistration(It.IsAny<CloudEvent>())).ReturnsAsync(responseId);
 
                 HttpClient client = GetTestClient(eventsService.Object);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));
@@ -112,7 +112,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 CloudEventRequestModel cloudEvent = GetCloudEventRequest();
 
                 Mock<IEventsService> eventsService = new Mock<IEventsService>();
-                eventsService.Setup(s => s.SaveAndPostInbound(It.IsAny<CloudEvent>())).ReturnsAsync(responseId);
+                eventsService.Setup(s => s.PostRegistration(It.IsAny<CloudEvent>())).ReturnsAsync(responseId);
 
                 HttpClient client = GetTestClient(eventsService.Object);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));
@@ -179,7 +179,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 string requestUri = $"{BasePath}/app";
                 CloudEventRequestModel cloudEvent = GetCloudEventRequest();
                 Mock<IEventsService> eventsService = new Mock<IEventsService>();
-                eventsService.Setup(er => er.SaveAndPostInbound(It.IsAny<CloudEvent>())).Throws(new Exception());
+                eventsService.Setup(er => er.PostRegistration(It.IsAny<CloudEvent>())).Throws(new Exception());
                 HttpClient client = GetTestClient(eventsService.Object);
 
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
@@ -132,14 +132,14 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
             /// <summary>
             /// Scenario:
-            ///   Post a invalid CloudEvent instance.
+            ///   Post an invalid CloudEvent instance.
             /// Expected result:
             ///   Returns HttpStatus BadRequest.
             /// Success criteria:
             ///   The response has correct status.
             /// </summary>
             [Fact]
-            public async void Post_InValidCloudEvent_ReturnsStatusBadRequest()
+            public async void Post_CloudEventMissingSubject_ReturnsStatusBadRequest()
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app";

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
@@ -166,6 +166,74 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
             /// <summary>
             /// Scenario:
+            ///   Post a invalid CloudEvent instance.
+            /// Expected result:
+            ///   Returns HttpStatus BadRequest.
+            /// Success criteria:
+            ///   The response has correct status.
+            /// </summary>
+            [Fact]
+            public async void Post_CloudEventMissingSource_ReturnsStatusBadRequest()
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/app";
+                CloudEventRequestModel cloudEvent = GetCloudEventRequest();
+                cloudEvent.Source = null;
+
+                Mock<IEventsService> eventsService = new Mock<IEventsService>();
+
+                HttpClient client = GetTestClient(eventsService.Object);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
+                {
+                    Content = new StringContent(cloudEvent.Serialize(), Encoding.UTF8, "application/json")
+                };
+
+                httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            }
+
+            /// <summary>
+            /// Scenario:
+            ///   Post a invalid CloudEvent instance.
+            /// Expected result:
+            ///   Returns HttpStatus BadRequest.
+            /// Success criteria:
+            ///   The response has correct status.
+            /// </summary>
+            [Fact]
+            public async void Post_CloudEventOrgDoesNotMatch_ReturnsStatusBadRequest()
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/app";
+                CloudEventRequestModel cloudEvent = GetCloudEventRequest("skd");
+                cloudEvent.Source = null;
+
+                Mock<IEventsService> eventsService = new Mock<IEventsService>();
+
+                HttpClient client = GetTestClient(eventsService.Object);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1));
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
+                {
+                    Content = new StringContent(cloudEvent.Serialize(), Encoding.UTF8, "application/json")
+                };
+
+                httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            }
+
+            /// <summary>
+            /// Scenario:
             ///   Post a valid cloud event, unexpected error when storing document
             /// Expected result:
             ///   Returns HttpStatus Internal Server Error.
@@ -865,13 +933,13 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 return client;
             }
 
-            private static CloudEventRequestModel GetCloudEventRequest()
+            private static CloudEventRequestModel GetCloudEventRequest(string org = "ttd")
             {
                 CloudEventRequestModel cloudEvent = new CloudEventRequestModel
                 {
                     SpecVersion = "1.0",
                     Type = "instance.created",
-                    Source = new Uri("https://ttd.apps.altinn.no/ttd/endring-av-navn-v2/232243423"),
+                    Source = new Uri($"https://{org}.apps.altinn.no/{org}/endring-av-navn-v2/232243423"),
                     Subject = "/party/456456",
                     Data = "something/extra",
                 };

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
@@ -212,7 +212,6 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 // Arrange
                 string requestUri = $"{BasePath}/app";
                 CloudEventRequestModel cloudEvent = GetCloudEventRequest("skd");
-                cloudEvent.Source = null;
 
                 Mock<IEventsService> eventsService = new Mock<IEventsService>();
 
@@ -229,7 +228,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
                 // Assert
-                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
             }
 
             /// <summary>

--- a/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
@@ -42,27 +42,6 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Store a CloudEvent in postgres DB. Push event to events-inbound queue.
-        /// Expected result:
-        ///   Returns the id of the newly created document.
-        /// Success criteria:
-        ///   The response is a non-empty string.
-        /// </summary>
-        [Fact]
-        public async Task StoreAndPushEvent_EventSuccessfullyStored_IdReturned()
-        {
-            // Arrange
-            EventsService eventsService = GetEventsService();
-
-            // Act
-            string actual = await eventsService.SaveAndPostInbound(GetCloudEvent());
-
-            // Assert
-            Assert.NotEmpty(actual);
-        }
-
-        /// <summary>
-        /// Scenario:
         ///   Push cloud event to events-inbound queue.
         /// Expected result:
         ///   Returns the id of the previously created document.
@@ -112,7 +91,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
         ///   The response is a non-empty string.
         /// </summary>
         [Fact]
-        public async Task SaveAndPushNewEvent_CheckIdCreatedByService_IdReturned()
+        public async Task RegisterNewEvent_CheckIdCreatedByService_IdReturned()
         {
             // Arrange
             EventsService eventsService = GetEventsService();
@@ -121,7 +100,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             item.Id = null;
 
             // Act
-            string actual = await eventsService.SaveAndPostInbound(item);
+            string actual = await eventsService.PostRegistration(item);
 
             // Assert
             Assert.NotEmpty(actual);
@@ -136,17 +115,17 @@ namespace Altinn.Platform.Events.Tests.TestingServices
         ///  Error is logged.
         /// </summary>
         [Fact]
-        public async Task SaveAndPushNewEvent_PushEventFails_ErrorIsLogged()
+        public async Task RegisterNewEvent_PushEventFails_ErrorIsLogged()
         {
             // Arrange
             Mock<IEventsQueueClient> queueMock = new Mock<IEventsQueueClient>();
-            queueMock.Setup(q => q.EnqueueInbound(It.IsAny<string>())).ReturnsAsync(new QueuePostReceipt { Success = false, Exception = new Exception("The push failed due to something") });
+            queueMock.Setup(q => q.EnqueueRegistration(It.IsAny<string>())).ReturnsAsync(new QueuePostReceipt { Success = false, Exception = new Exception("The push failed due to something") });
 
             Mock<ILogger<IEventsService>> logger = new Mock<ILogger<IEventsService>>();
             EventsService eventsService = GetEventsService(loggerMock: logger, queueMock: queueMock.Object);
 
             // Act
-            await eventsService.SaveAndPostInbound(GetCloudEvent());
+            await eventsService.PostRegistration(GetCloudEvent());
 
             // Assert
             logger.Verify(x => x.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);

--- a/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
@@ -100,7 +100,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             item.Id = null;
 
             // Act
-            string actual = await eventsService.PostRegistration(item);
+            string actual = await eventsService.RegisterNew(item);
 
             // Assert
             Assert.NotEmpty(actual);
@@ -125,7 +125,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             EventsService eventsService = GetEventsService(loggerMock: logger, queueMock: queueMock.Object);
 
             // Act
-            await eventsService.PostRegistration(GetCloudEvent());
+            await eventsService.RegisterNew(GetCloudEvent());
 
             // Assert
             logger.Verify(x => x.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);

--- a/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
@@ -125,7 +125,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             EventsService eventsService = GetEventsService(loggerMock: logger, queueMock: queueMock.Object);
 
             // Act
-            await eventsService.RegisterNew(GetCloudEvent());
+            await Assert.ThrowsAsync<Exception>(() => eventsService.RegisterNew(GetCloudEvent()));
 
             // Assert
             logger.Verify(x => x.Log(LogLevel.Error, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);


### PR DESCRIPTION
Activate usage of events-registration queue for incoming cloud events.

## Description
Infrastructure for processing events in `events-registration` queue has been tested and verified. This PR makes the new flow active for all new events.


## Related Issue(s)
- #124 
- #112 

## Verification
- [x] Code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
