### PR TITLE
SQL: FUNCTION with no OUT params must be PROCEDURE

### DIFF
--- a/src/Events/Migration/v0.17/01-setup-functions.sql
+++ b/src/Events/Migration/v0.17/01-setup-functions.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION events.insertevent(
+CREATE OR REPLACE PROCEDURE events.insertevent(
 	id character varying,
 	source character varying,
 	subject character varying,

--- a/src/Events/Repository/CloudEventRepository.cs
+++ b/src/Events/Repository/CloudEventRepository.cs
@@ -20,7 +20,7 @@ namespace Altinn.Platform.Events.Repository
     [ExcludeFromCodeCoverage]
     public class CloudEventRepository : ICloudEventRepository
     {
-        private readonly string insertEventSql = "select events.insertevent(@id, @source, @subject, @type, @time, @cloudevent)";
+        private readonly string insertEventSql = "call events.insertevent(@id, @source, @subject, @type, @time, @cloudevent)";
         private readonly string getEventSql = "select events.get(@_subject, @_after, @_from, @_to, @_type, @_source, @_size)";
         private readonly string _connectionString;
 


### PR DESCRIPTION
"cloudevent" is no longer an INOUT param so must use PROCEDURE instead of FUNCTION.