### PR TITLE
Drop function before creating PROC with same name and signature

### DIFF
--- a/src/Events/Migration/v0.17/01-setup-functions.sql
+++ b/src/Events/Migration/v0.17/01-setup-functions.sql
@@ -1,3 +1,5 @@
+DROP FUNCTION IF EXISTS events.insertevent(character varying, character varying, character varying, character varying, timestamptz, text);
+
 CREATE OR REPLACE PROCEDURE events.insertevent(
 	id character varying,
 	source character varying,


### PR DESCRIPTION
Can not change existing function to procedure, must drop first.