### PR TITLE
Create Swagger tag description for private API endpoints

### DIFF
--- a/src/Events/Controllers/InboundController.cs
+++ b/src/Events/Controllers/InboundController.cs
@@ -22,6 +22,7 @@ namespace Altinn.Platform.Events.Controllers
     /// </summary>
     [Route("events/api/v1/inbound")]
     [ApiController]
+    [SwaggerTag("Private API")]
     public class InboundController : ControllerBase
     {
         private static readonly CloudEventFormatter _formatter = new JsonEventFormatter();

--- a/src/Events/Controllers/OutboundController.cs
+++ b/src/Events/Controllers/OutboundController.cs
@@ -2,15 +2,18 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+
 using Altinn.Platform.Events.Extensions;
 using Altinn.Platform.Events.Services.Interfaces;
 
 using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.SystemTextJson;
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace Altinn.Platform.Events.Controllers
 {
@@ -19,6 +22,7 @@ namespace Altinn.Platform.Events.Controllers
     /// </summary>
     [Route("events/api/v1/outbound")]
     [ApiController]
+    [SwaggerTag("Private API")]
     public class OutboundController : ControllerBase
     {
         private static readonly CloudEventFormatter _formatter = new JsonEventFormatter();

--- a/src/Events/Controllers/PushController.cs
+++ b/src/Events/Controllers/PushController.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 
-using Altinn.Platform.Events.Models;
 using Altinn.Platform.Events.Services.Interfaces;
 
 using CloudNative.CloudEvents;
@@ -8,6 +7,7 @@ using CloudNative.CloudEvents;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace Altinn.Platform.Events.Controllers
 {
@@ -16,6 +16,7 @@ namespace Altinn.Platform.Events.Controllers
     /// </summary>
     [Route("events/api/v1/push")]
     [ApiController]
+    [SwaggerTag("Private API")]
     public class PushController : ControllerBase
     {
         private readonly IOutboundService _outboundService;

--- a/src/Events/Controllers/StorageController.cs
+++ b/src/Events/Controllers/StorageController.cs
@@ -23,6 +23,7 @@ namespace Altinn.Platform.Events.Controllers
     /// </summary>
     [Route("events/api/v1/storage/events")]
     [ApiController]
+    [SwaggerTag("Private API")]
     public class StorageController : ControllerBase
     {
         private static readonly CloudEventFormatter _formatter = new JsonEventFormatter();


### PR DESCRIPTION
Add a "Private API" description to the tags of internal API endpoints.
Makes it easier to not confuse them with the public available endpoints in the Swagger documentation.

PR for docs: https://github.com/Altinn/altinn-studio-docs/pull/762

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Produces the following change to the OpenAPI specification
```json
"tags": [
    {
      "name": "Inbound",
      "description": "Private API"
    },
    {
      "name": "Outbound",
      "description": "Private API"
    },
    {
      "name": "Push",
      "description": "Private API"
    },
    {
      "name": "Storage",
      "description": "Private API"
    }
  ]
```

## Related Issue(s)
- just a minor tweak.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
