### PR TITLE
not throwing exception of 404 respnse to validate

### DIFF
--- a/src/Events.Functions/Clients/EventsClient.cs
+++ b/src/Events.Functions/Clients/EventsClient.cs
@@ -124,6 +124,13 @@ namespace Altinn.Platform.Events.Functions.Clients
             string endpointUrl = "subscriptions/validate/" + subscriptionId;
 
             HttpResponseMessage response = await _client.PutAsync(endpointUrl, null, accessToken);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogError("Attempting to validate non existing subscription {subscriptionId}", subscriptionId);
+                return;
+            }
+            
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogError(

--- a/test/Altinn.Platform.Events.Functions.Tests/TestingClients/EventsClientTests.cs
+++ b/test/Altinn.Platform.Events.Functions.Tests/TestingClients/EventsClientTests.cs
@@ -235,6 +235,30 @@ namespace Altinn.Platform.Events.Functions.Tests.TestingClients
                 (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
         }
 
+        [Fact]
+        public async Task ValidateSubscription_NotFoundResponse_ErrorLoggedNoExceptionThrown()
+        {
+            // Arrange
+            var handlerMock = CreateMessageHandlerMock(
+                "https://platform.test.altinn.cloud/events/api/v1/subscriptions/validate/1337",
+                HttpStatusCode.NotFound);
+
+            var sut = CreateTestInstance(handlerMock.Object);
+
+            // Act
+
+            await sut.ValidateSubscription(1337);
+
+            // Assert
+            handlerMock.VerifyAll();
+            _loggerMock.Verify(x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Attempting to validate non existing subscription 1337")),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()), Times.Once);
+        }
+
         private static Mock<HttpMessageHandler> CreateMessageHandlerMock(string clientEndpoint, HttpStatusCode statusCode)
         {
             var messageHandlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
no longer throwing exception in eventsClient  if validate subscription returns 404. Simply logging error and returning. 
Goal is to not retry validation for subscriptions we cannot find in the database.

## Related Issue(s)
- #250

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
~~- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [x] All tests run green
