### PR TITLE
Feature/108 get generic events

### DIFF
--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Run events use case tests
       run:  |
               cd test/k6
-              docker-compose run k6 run /src/tests/events.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
+              docker-compose run k6 run /src/tests/events/post.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
     - name: Run subscription use case tests
       run:  |
               cd test/k6

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -23,6 +23,7 @@ jobs:
       run:  |
               cd test/k6
               docker-compose run k6 run /src/tests/events/post.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
+              docker-compose run k6 run /src/tests/events/get.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
     - name: Run subscription use case tests
       run:  |
               cd test/k6

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,24 @@ cross/rootfs/
 *.sln.ide
 *.ide/
 
+# IntelliJ
+.idea/
+
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.Altinn.Platform.Events.iml
+/contentModel.xml
+/projectSettingsUpdater.xml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/src/Events/Altinn.Platform.Events.csproj
+++ b/src/Events/Altinn.Platform.Events.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
     <PackageReference Include="Yuniql.PostgreSql" Version="1.3.15" />
   </ItemGroup>

--- a/src/Events/Configuration/AuthorizationConstants.cs
+++ b/src/Events/Configuration/AuthorizationConstants.cs
@@ -13,6 +13,11 @@
         /// <summary>
         /// Scope for allowing subscribing to events
         /// </summary>
+        public const string SCOPE_EVENTS_PUBLISH = "altinn:events.publish";
+
+        /// <summary>
+        /// Scope for allowing subscribing to events
+        /// </summary>
         public const string SCOPE_EVENTS_SUBSCRIBE = "altinn:events.subscribe";
     }
 }

--- a/src/Events/Configuration/GeneralSettings.cs
+++ b/src/Events/Configuration/GeneralSettings.cs
@@ -6,9 +6,9 @@ namespace Altinn.Platform.Events.Configuration
     public class GeneralSettings
     {
         /// <summary>
-        /// Hostname
+        /// Base Uri
         /// </summary>
-        public string Hostname { get; set; }
+        public string BaseUri { get; set; }
 
         /// <summary>
         /// Open Id Connect Well known endpoint

--- a/src/Events/Controllers/AppController.cs
+++ b/src/Events/Controllers/AppController.cs
@@ -48,7 +48,7 @@ namespace Altinn.Platform.Events.Controllers
         {
             _logger = logger;
             _eventsService = eventsService;
-            _eventsBaseUri = $"https://platform.{settings.Value.Hostname}";
+            _eventsBaseUri = settings.Value.BaseUri;
             _accessTokenSettings = accessTokenSettings.Value;
         }
 

--- a/src/Events/Controllers/EventsController.cs
+++ b/src/Events/Controllers/EventsController.cs
@@ -92,8 +92,7 @@ namespace Altinn.Platform.Events.Controllers
         [Consumes("application/json")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-
-        // [Authorize(Policy = AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE)]
+        [Authorize(Policy = AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE)]
         [Produces("application/cloudevents+json")]
         public async Task<ActionResult<List<CloudEvent>>> Get(
             [FromQuery] string after,

--- a/src/Events/Controllers/EventsController.cs
+++ b/src/Events/Controllers/EventsController.cs
@@ -44,7 +44,7 @@ namespace Altinn.Platform.Events.Controllers
             _eventsService = events;
             _logger = logger;
             _settings = settings.Value;
-            _eventsBaseUri = $"https://platform.{settings.Value.Hostname}";
+            _eventsBaseUri = settings.Value.BaseUri;
         }
 
         /// <summary>

--- a/src/Events/Controllers/EventsController.cs
+++ b/src/Events/Controllers/EventsController.cs
@@ -14,6 +14,7 @@ using CloudNative.CloudEvents;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -82,10 +83,10 @@ namespace Altinn.Platform.Events.Controllers
         /// </summary>
         /// <param name="after" example="3fa85f64-5717-4562-b3fc-2c963f66afa6">Retrieve events that were registered after this event Id</param>
         /// <param name="source" example="[&quot;https://ttd.apps.at22.altinn.cloud/ttd/apps-test/&quot;
-        /// , &quot;https://ttd.apps.at22.altinn.cloud/digdir/bli-tjenesteeier/&quot;, &quot;https://ttd.apps.at22.altinn.cloud/ttd/apps-%/&quot;]">
-        /// A list of the sources to include</param>
-        /// <param name="type" example="[&quot;app.instance.created&quot;, &quot;app.instance.process.completed&quot;]">
-        /// A list of the event types to include</param>
+        /// , &quot;https://ttd.apps.at22.altinn.cloud/digdir/bli-tjenesteeier/&quot;]">
+        /// Optional list of zero or more sources to include</param>
+        /// <param name="type" example="[&quot;instance.created&quot;, &quot;instance.process.completed&quot;]">
+        /// Optional list of zero or more event types to include</param>
         /// <param name="subject">Optional filter by subject. Only exact matches will be returned.</param>
         /// <param name="size">The maximum number of events to include in the response.</param>
         [HttpGet()]
@@ -95,7 +96,7 @@ namespace Altinn.Platform.Events.Controllers
         [Authorize(Policy = AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE)]
         [Produces("application/cloudevents+json")]
         public async Task<ActionResult<List<CloudEvent>>> Get(
-            [FromQuery] string after,
+            [FromQuery, BindRequired] string after,
             [FromQuery] List<string> source,
             [FromQuery] List<string> type,
             [FromHeader] string subject,

--- a/src/Events/Controllers/EventsController.cs
+++ b/src/Events/Controllers/EventsController.cs
@@ -97,12 +97,12 @@ namespace Altinn.Platform.Events.Controllers
         [Produces("application/cloudevents+json")]
         public async Task<ActionResult<List<CloudEvent>>> Get(
             [FromQuery, BindRequired] string after,
-            [FromQuery] List<string> source,
+            [FromQuery, BindRequired] List<string> source,
             [FromQuery] List<string> type,
             [FromHeader] string subject,
             [FromQuery] int size = 50)
         {
-            (bool isValid, string errorMessage) = ValidateQueryParams(after, size);
+            (bool isValid, string errorMessage) = ValidateQueryParams(after, size, source);
 
             if (!isValid)
             {
@@ -121,7 +121,7 @@ namespace Altinn.Platform.Events.Controllers
             }
         }
 
-        private static (bool IsValid, string ErrorMessage) ValidateQueryParams(string after, int size)
+        private static (bool IsValid, string ErrorMessage) ValidateQueryParams(string after, int size, List<string> source)
         {
             if (string.IsNullOrEmpty(after))
             {
@@ -131,6 +131,11 @@ namespace Altinn.Platform.Events.Controllers
             if (size < 1)
             {
                 return (false, "The 'size' parameter must be a number larger that 0.");
+            }
+
+            if (source.Count == 0)
+            {
+                return (false, "The 'source' parameter must contain at least one value.");
             }
 
             return (true, null);

--- a/src/Events/Controllers/EventsController.cs
+++ b/src/Events/Controllers/EventsController.cs
@@ -78,21 +78,22 @@ namespace Altinn.Platform.Events.Controllers
         }
 
         /// <summary>
-        /// Retrieves a set of events related to a party based on query parameters.
+        /// Retrieves a set of events related based on query parameters.
         /// </summary>
-        /// <param name="after" example="3fa85f64-5717-4562-b3fc-2c963f66afa6">Id of the latter event that should be included</param>
+        /// <param name="after" example="3fa85f64-5717-4562-b3fc-2c963f66afa6">Retrieve events that were registered after this event Id</param>
         /// <param name="source" example="[&quot;https://ttd.apps.at22.altinn.cloud/ttd/apps-test/&quot;
         /// , &quot;https://ttd.apps.at22.altinn.cloud/digdir/bli-tjenesteeier/&quot;, &quot;https://ttd.apps.at22.altinn.cloud/ttd/apps-%/&quot;]">
         /// A list of the sources to include</param>
         /// <param name="type" example="[&quot;app.instance.created&quot;, &quot;app.instance.process.completed&quot;]">
         /// A list of the event types to include</param>
         /// <param name="subject">Optional filter by subject. Only exact matches will be returned.</param>
-        /// <param name="size">The maximum number of events to include in the response</param>
-        [HttpGet("party")]
+        /// <param name="size">The maximum number of events to include in the response.</param>
+        [HttpGet()]
         [Consumes("application/json")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [Authorize(Policy = AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE)]
+
+        // [Authorize(Policy = AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE)]
         [Produces("application/cloudevents+json")]
         public async Task<ActionResult<List<CloudEvent>>> Get(
             [FromQuery] string after,
@@ -121,10 +122,15 @@ namespace Altinn.Platform.Events.Controllers
         }
 
         private static (bool IsValid, string ErrorMessage) ValidateQueryParams(string after, int size)
-        {            
+        {
+            if (string.IsNullOrEmpty(after))
+            {
+                return (false, "The 'after' parameter must be defined.");
+            }
+
             if (size < 1)
             {
-                return (false, "The 'Size' parameter must be a number larger that 0.");
+                return (false, "The 'size' parameter must be a number larger that 0.");
             }
 
             return (true, null);

--- a/src/Events/Controllers/SubscriptionController.cs
+++ b/src/Events/Controllers/SubscriptionController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Events.Configuration;
@@ -78,7 +79,9 @@ namespace Altinn.Platform.Events.Controllers
             if (!subscriptionRequest.SourceFilter.DnsSafeHost.EndsWith(_settings.AppsDomain))
             {
                 // Only non Altinn App subscriptions require the additional scope
-                if (!_claimsPrincipalProvider.GetUser().HasRequiredScope(AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE))
+                ClaimsPrincipal principal = _claimsPrincipalProvider.GetUser();
+
+                if (!principal.HasRequiredScope(AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE))
                 {
                     return Forbid();
                 }

--- a/src/Events/Migration/v0.25/01-alter-function.sql
+++ b/src/Events/Migration/v0.25/01-alter-function.sql
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION events.getevents(
+	_subject character varying,
+	_after character varying,
+	_type text[],
+	_source text[],
+	_size integer)
+    RETURNS TABLE(cloudevents text)
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+    ROWS 1000
+
+AS $BODY$
+BEGIN
+return query
+	SELECT events.events.cloudevent
+	FROM events.events
+	WHERE (_subject = '' OR events.subject = _subject)
+	AND (_type IS NULL OR events.type ILIKE ANY(_type) )
+	AND (_source IS NULL OR events.source ILIKE ANY(_source))
+	AND (_after = '' OR events.sequenceno >(
+		SELECT
+			case count(*)
+			when 0
+				then 0
+			else
+				(SELECT sequenceno
+				FROM events.events
+				WHERE id = _after
+				ORDER BY sequenceno ASC
+				LIMIT 1)
+			end
+		FROM events.events
+		WHERE id = _after))
+  ORDER BY events.sequenceno
+  limit _size;
+END;
+$BODY$;

--- a/src/Events/Migration/v0.25/01-alter-function.sql
+++ b/src/Events/Migration/v0.25/01-alter-function.sql
@@ -13,12 +13,12 @@ CREATE OR REPLACE FUNCTION events.getevents(
 AS $BODY$
 BEGIN
 return query
-	SELECT events.events.cloudevent
+	SELECT cast(cloudevent as text) as cloudevents
 	FROM events.events
-	WHERE (_subject = '' OR events.subject = _subject)
-	AND (_type IS NULL OR events.type ILIKE ANY(_type) )
-	AND (_source IS NULL OR events.source ILIKE ANY(_source))
-	AND (_after = '' OR events.sequenceno >(
+	WHERE (_subject IS NULL OR cloudevent->>'subject' = _subject)
+	AND (_type IS NULL OR cloudevent->>'type' ILIKE ANY(_type) )
+	AND (_source IS NULL OR cloudevent->>'source' ILIKE ANY(_source))
+	AND (_after = '' OR sequenceno >(
 		SELECT
 			case count(*)
 			when 0
@@ -26,13 +26,13 @@ return query
 			else
 				(SELECT sequenceno
 				FROM events.events
-				WHERE id = _after
+				WHERE cloudevent->>'id' = _after
 				ORDER BY sequenceno ASC
 				LIMIT 1)
 			end
 		FROM events.events
-		WHERE id = _after))
-  ORDER BY events.sequenceno
+		WHERE cloudevent->>'id' = _after))
+  ORDER BY sequenceno
   limit _size;
 END;
 $BODY$;

--- a/src/Events/Program.cs
+++ b/src/Events/Program.cs
@@ -226,6 +226,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     {
         options.AddPolicy("PlatformAccess", policy => policy.Requirements.Add(new AccessTokenRequirement()));
         options.AddPolicy(AuthorizationConstants.POLICY_SCOPE_EVENTS_PUBLISH, policy => policy.Requirements.Add(new ScopeAccessRequirement("altinn:events.publish")));
+        options.AddPolicy(AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE, policy => policy.Requirements.Add(new ScopeAccessRequirement("altinn:events.subscribe")));
     });
 
     services.AddControllers(opts =>

--- a/src/Events/Program.cs
+++ b/src/Events/Program.cs
@@ -224,9 +224,17 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
 
     services.AddAuthorization(options =>
     {
-        options.AddPolicy("PlatformAccess", policy => policy.Requirements.Add(new AccessTokenRequirement()));
-        options.AddPolicy(AuthorizationConstants.POLICY_SCOPE_EVENTS_PUBLISH, policy => policy.Requirements.Add(new ScopeAccessRequirement("altinn:events.publish")));
-        options.AddPolicy(AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE, policy => policy.Requirements.Add(new ScopeAccessRequirement("altinn:events.subscribe")));
+        options.AddPolicy(
+            "PlatformAccess", 
+            policy => policy.Requirements.Add(new AccessTokenRequirement()));
+
+        options.AddPolicy(
+            AuthorizationConstants.POLICY_SCOPE_EVENTS_PUBLISH, 
+            policy => policy.Requirements.Add(new ScopeAccessRequirement(AuthorizationConstants.SCOPE_EVENTS_PUBLISH)));
+
+        options.AddPolicy(
+            AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE, 
+            policy => policy.Requirements.Add(new ScopeAccessRequirement(AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE)));
     });
 
     services.AddControllers(opts =>

--- a/src/Events/Program.cs
+++ b/src/Events/Program.cs
@@ -327,7 +327,7 @@ void IncludeXmlComments(SwaggerGenOptions swaggerGenOptions)
     }
     catch (Exception e)
     {
-        logger.LogWarning(e, "Prorgam // Exception when attempting to include the XML comments file(s).");
+        logger.LogWarning(e, "Program // Exception when attempting to include the XML comments file(s).");
     }
 }
 

--- a/src/Events/Repository/CloudEventRepository.cs
+++ b/src/Events/Repository/CloudEventRepository.cs
@@ -26,6 +26,7 @@ namespace Altinn.Platform.Events.Repository
         private readonly string insertAppEventSql = "call events.insertappevent(@id, @source, @subject, @type, @time, @cloudevent)";
         private readonly string insertEventSql = "insert into events.events(cloudevent) VALUES ($1);";
         private readonly string getAppEventsSql = "select events.getappevents(@_subject, @_after, @_from, @_to, @_type, @_source, @_size)";
+        private readonly string getEventsSql = "select events.getevents(@_subject, @_after, @_type, @_source, @_size)";
         private readonly string _connectionString;
 
         /// <summary>
@@ -98,6 +99,33 @@ namespace Altinn.Platform.Events.Repository
             pgcom.Parameters.AddWithValue("_to", NpgsqlDbType.TimestampTz, to ?? (object)DBNull.Value);
             pgcom.Parameters.AddWithValue("_type", NpgsqlDbType.Array | NpgsqlDbType.Text, type ?? (object)DBNull.Value);
             pgcom.Parameters.AddWithValue("_source", NpgsqlDbType.Array | NpgsqlDbType.Text, source ?? (object)DBNull.Value);
+            pgcom.Parameters.AddWithValue("_size", NpgsqlDbType.Integer, size);
+
+            await using (NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    CloudEvent cloudEvent = DeserializeAndConvertTime(reader[0].ToString());
+                    searchResult.Add(cloudEvent);
+                }
+            }
+
+            return searchResult;
+        }
+
+        /// <inheritdoc/>
+        public async Task<List<CloudEvent>> GetEvents(string after, List<string> source, List<string> type, string subject, int size)
+        {
+            List<CloudEvent> searchResult = new List<CloudEvent>();
+
+            await using NpgsqlConnection conn = new NpgsqlConnection(_connectionString);
+            await conn.OpenAsync();
+
+            await using NpgsqlCommand pgcom = new NpgsqlCommand(getEventsSql, conn);
+            pgcom.Parameters.AddWithValue("_after", NpgsqlDbType.Varchar, after);
+            pgcom.Parameters.AddWithValue("_type", NpgsqlDbType.Array | NpgsqlDbType.Text, type ?? (object)DBNull.Value);
+            pgcom.Parameters.AddWithValue("_source", NpgsqlDbType.Array | NpgsqlDbType.Text, source ?? (object)DBNull.Value);
+            pgcom.Parameters.AddWithValue("_subject", NpgsqlDbType.Varchar, subject);
             pgcom.Parameters.AddWithValue("_size", NpgsqlDbType.Integer, size);
 
             await using (NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync())

--- a/src/Events/Repository/CloudEventRepository.cs
+++ b/src/Events/Repository/CloudEventRepository.cs
@@ -4,15 +4,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
-
 using Altinn.Platform.Events.Configuration;
-
 using CloudNative.CloudEvents;
-
 using Microsoft.Extensions.Options;
-
 using Npgsql;
-
 using NpgsqlTypes;
 
 namespace Altinn.Platform.Events.Repository

--- a/src/Events/Repository/CloudEventRepository.cs
+++ b/src/Events/Repository/CloudEventRepository.cs
@@ -123,8 +123,10 @@ namespace Altinn.Platform.Events.Repository
 
             await using NpgsqlCommand pgcom = new NpgsqlCommand(getEventsSql, conn);
             pgcom.Parameters.AddWithValue("_after", NpgsqlDbType.Varchar, after);
+#pragma warning disable // ignore missing [Flags] attribute. See https://github.com/npgsql/npgsql/issues/2801
             pgcom.Parameters.AddWithValue("_type", NpgsqlDbType.Array | NpgsqlDbType.Text, type ?? (object)DBNull.Value);
             pgcom.Parameters.AddWithValue("_source", NpgsqlDbType.Array | NpgsqlDbType.Text, source ?? (object)DBNull.Value);
+#pragma warning restore
             pgcom.Parameters.AddWithValue("_subject", NpgsqlDbType.Varchar, subject);
             pgcom.Parameters.AddWithValue("_size", NpgsqlDbType.Integer, size);
 

--- a/src/Events/Repository/CloudEventRepository.cs
+++ b/src/Events/Repository/CloudEventRepository.cs
@@ -123,10 +123,13 @@ namespace Altinn.Platform.Events.Repository
 
             await using NpgsqlCommand pgcom = new NpgsqlCommand(getEventsSql, conn);
             pgcom.Parameters.AddWithValue("_after", NpgsqlDbType.Varchar, after);
-#pragma warning disable // ignore missing [Flags] attribute. See https://github.com/npgsql/npgsql/issues/2801
+#pragma warning disable S3265 
+
+            // ignore missing [Flags] attribute on NpgsqlDbType enum.
+            // For more info: https://github.com/npgsql/npgsql/issues/2801
             pgcom.Parameters.AddWithValue("_type", NpgsqlDbType.Array | NpgsqlDbType.Text, type ?? (object)DBNull.Value);
             pgcom.Parameters.AddWithValue("_source", NpgsqlDbType.Array | NpgsqlDbType.Text, source ?? (object)DBNull.Value);
-#pragma warning restore
+#pragma warning restore S3265
             pgcom.Parameters.AddWithValue("_subject", NpgsqlDbType.Varchar, subject);
             pgcom.Parameters.AddWithValue("_size", NpgsqlDbType.Integer, size);
 

--- a/src/Events/Repository/ICloudEventRepository.cs
+++ b/src/Events/Repository/ICloudEventRepository.cs
@@ -28,5 +28,10 @@ namespace Altinn.Platform.Events.Repository
         /// Calls a function to retrieve app cloud events based on query params
         /// </summary>
         Task<List<CloudEvent>> GetAppEvents(string after, DateTime? from, DateTime? to, string subject, List<string> source, List<string> type, int size);
+
+        /// <summary>
+        /// Calls a function to retrieve app cloud events based on query params
+        /// </summary>
+        Task<List<CloudEvent>> GetEvents(string after, List<string> source, List<string> type, string subject, int size);
     }
 }

--- a/src/Events/Repository/ICloudEventRepository.cs
+++ b/src/Events/Repository/ICloudEventRepository.cs
@@ -30,7 +30,7 @@ namespace Altinn.Platform.Events.Repository
         Task<List<CloudEvent>> GetAppEvents(string after, DateTime? from, DateTime? to, string subject, List<string> source, List<string> type, int size);
 
         /// <summary>
-        /// Calls a function to retrieve app cloud events based on query params
+        /// Calls a function to retrieve cloud events based on query params
         /// </summary>
         Task<List<CloudEvent>> GetEvents(string after, List<string> source, List<string> type, string subject, int size);
     }

--- a/src/Events/Repository/SubscriptionRepository.cs
+++ b/src/Events/Repository/SubscriptionRepository.cs
@@ -3,15 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Altinn.Platform.Events.Configuration;
 using Altinn.Platform.Events.Extensions;
 using Altinn.Platform.Events.Models;
-
 using Microsoft.Extensions.Options;
-
 using Npgsql;
-
 using NpgsqlTypes;
 
 namespace Altinn.Platform.Events.Repository

--- a/src/Events/Services/EventsService.cs
+++ b/src/Events/Services/EventsService.cs
@@ -17,11 +17,7 @@ using Microsoft.Extensions.Options;
 namespace Altinn.Platform.Events.Services
 {
     /// <summary>
-    /// Handles events service. 
-    /// Notice when saving cloudEvent:
-    /// - the id for the cloudEvent is created by the app
-    /// - time is set by the database when calling SaveAndPostInbound
-    ///   or by the service when calling PushToRegistrationQueue
+    /// Functionality for registering and forwarding cloud events. 
     /// </summary>
     public class EventsService : IEventsService
     {

--- a/src/Events/Services/EventsService.cs
+++ b/src/Events/Services/EventsService.cs
@@ -128,7 +128,7 @@ namespace Altinn.Platform.Events.Services
         }
 
         /// <inheritdoc/>
-        public async Task<List<CloudEvent>> GetEvents(string after, List<string> source, List<string> type, string subject, int size = 50)
+        public async Task<List<CloudEvent>> GetEvents(string after, List<string> source, List<string> type, string subject, int size)
         {
             source = source.Count > 0 ? source : null;
             type = type.Count > 0 ? type : null;

--- a/src/Events/Services/EventsService.cs
+++ b/src/Events/Services/EventsService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Events.Clients.Interfaces;
@@ -123,6 +122,23 @@ namespace Altinn.Platform.Events.Services
             after ??= string.Empty;
 
             List<CloudEvent> events = await _repository.GetAppEvents(after, from, to, subject, source, type, size);
+
+            if (events.Count == 0)
+            {
+                return events;
+            }
+
+            return await _authorizationService.AuthorizeEvents(_claimsPrincipalProvider.GetUser(), events);
+        }
+
+        /// <inheritdoc/>
+        public async Task<List<CloudEvent>> GetEvents(string after, List<string> source, List<string> type, string subject, int size = 50)
+        {
+            source = source.Count > 0 ? source : null;
+            type = type.Count > 0 ? type : null;
+            after ??= string.Empty;
+
+            List<CloudEvent> events = await _repository.GetEvents(after, source, type, subject, size);
 
             if (events.Count == 0)
             {

--- a/src/Events/Services/Interfaces/IEventsService.cs
+++ b/src/Events/Services/Interfaces/IEventsService.cs
@@ -42,6 +42,6 @@ namespace Altinn.Platform.Events.Services.Interfaces
         /// <summary>
         /// Gets list of cloud events based on query params
         /// </summary>
-        Task<List<CloudEvent>> GetEvents(string after, List<string> source, List<string> type, string subject, int size = 50);
+        Task<List<CloudEvent>> GetEvents(string after, List<string> source, List<string> type, string subject, int size);
     }
 }

--- a/src/Events/Services/Interfaces/IEventsService.cs
+++ b/src/Events/Services/Interfaces/IEventsService.cs
@@ -38,5 +38,10 @@ namespace Altinn.Platform.Events.Services.Interfaces
         /// Gets list of cloud events based on query params
         /// </summary>
         Task<List<CloudEvent>> GetAppEvents(string after, DateTime? from, DateTime? to, int partyId, List<string> source, List<string> type, string unit, string person, int size = 50);
+
+        /// <summary>
+        /// Gets list of cloud events based on query params
+        /// </summary>
+        Task<List<CloudEvent>> GetEvents(string after, List<string> source, List<string> type, string subject, int size = 50);
     }
 }

--- a/src/Events/appsettings.json
+++ b/src/Events/appsettings.json
@@ -8,7 +8,7 @@
     "EventsDbPwd": "Password"
   },
   "GeneralSettings": {
-    "Hostname": "localhost:5080",
+    "BaseUri": "http://localhost:5080",
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "JwtCookieName": "AltinnStudioRuntime"
   },

--- a/src/Events/appsettings.json
+++ b/src/Events/appsettings.json
@@ -8,7 +8,7 @@
     "EventsDbPwd": "Password"
   },
   "GeneralSettings": {
-    "BaseUri": "http://localhost:5080",
+    "BaseUri": "https://platform.localhost:5080",
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "JwtCookieName": "AltinnStudioRuntime"
   },

--- a/src/Events/appsettings.json
+++ b/src/Events/appsettings.json
@@ -3,7 +3,7 @@
     "EnableDBConnection": "true",
     "WorkspacePath": "Migration",
     "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_events_admin;Password={0};Database=eventsdb",
-    "ConnectionString": "Host=localhost;Port=5432;Username=platform_events;Password={0};Database=eventsdb",
+    "ConnectionString": "Host=localhost;Port=5432;Username=platform_events;Password={0};Database=eventsdb;Include Error Detail=True",
     "EventsDbAdminPwd": "Password",
     "EventsDbPwd": "Password"
   },

--- a/src/Events/appsettings.json
+++ b/src/Events/appsettings.json
@@ -8,7 +8,7 @@
     "EventsDbPwd": "Password"
   },
   "GeneralSettings": {
-    "BaseUri": "https://platform.localhost:5080",
+    "BaseUri": "http://localhost:5080",
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "JwtCookieName": "AltinnStudioRuntime"
   },

--- a/test/Altinn.Platform.Events.Tests/Data/events/3.json
+++ b/test/Altinn.Platform.Events.Tests/Data/events/3.json
@@ -1,0 +1,36 @@
+﻿[
+  {
+    "sequenceno": 1,
+    "id": "e31dbb11-2208-4dda-a549-92a0db8c7708",
+    "source": "urn:altinn:systemx",
+    "subject": "/party/1337",
+    "time": "2020-10-13T11:50:29Z",
+    "type": "instance.deleted",
+    "cloudEvent": {
+      "id": "e31dbb11-2208-4dda-a549-92a0db8c7708",
+      "source": "urn:altinn:systemx",
+      "specversion": "1.0",
+      "type": "instance.deleted",
+      "subject": "/party/1337",
+      "alternativesubject": "/person/01038712345",
+      "time": "2020-10-13T11:50:29Z"
+    }
+  },
+  {
+    "sequenceno": 2,
+    "id": "e31dbb11-2208-4dda-a549-92a0db8c8808",
+    "source": "urn:altinn:systemx",
+    "subject": "/party/1337",
+    "time": "2020-10-13T11:50:29Z",
+    "type": "instance.restored",
+    "cloudEvent": {
+      "id": "e31dbb11-2208-4dda-a549-92a0db8c8808",
+      "source": "urn:altinn:systemx",
+      "specversion": "1.0",
+      "type": "instance.deleted",
+      "subject": "/party/1337",
+      "alternativesubject": "/person/01038712345",
+      "time": "2020-10-13T12:50:29Z"
+    }
+  }
+]

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
@@ -378,14 +378,14 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
             /// <summary>
             /// Scenario:
-            ///   Post a cloud event, without bearer token.
+            ///   Retrieve a list of events, without bearer token.
             /// Expected result:
             ///   Returns HttpStatus Unauthorized.
             /// Success criteria:
             ///   The response has correct status.
             /// </summary>
             [Fact]
-            public async void GetForOrg_MissingBearerToken_ReturnsForbidden()
+            public async void GetForOrg_MissingBearerToken_ReturnsUnauthorized()
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app/ttd/endring-av-navn-v2?from=2020-01-01Z&party=1337";

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
@@ -413,7 +413,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app/ttd/endring-av-navn-v2?from=2020-01-01Z&party=1337";
-                string expectedNext = $"https://platform.localhost:5080/events/api/v1/app/ttd/endring-av-navn-v2?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337";
+                string expectedNext = $"http://localhost:5080/events/api/v1/app/ttd/endring-av-navn-v2?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337";
                 int expectedCount = 2;
 
                 HttpClient client = GetTestClient(new EventsServiceMock(1));
@@ -445,7 +445,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app/ttd/endring-av-navn-v2?after=e31dbb11-2208-4dda-a549-92a0db8c7708&from=2020-01-01Z&party=1337";
-                string expectedNext = $"https://platform.localhost:5080/events/api/v1/app/ttd/endring-av-navn-v2?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337";
+                string expectedNext = $"http://localhost:5080/events/api/v1/app/ttd/endring-av-navn-v2?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337";
                 int expectedCount = 1;
 
                 HttpClient client = GetTestClient(new EventsServiceMock(1));
@@ -678,7 +678,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app/party?from=2020-01-01Z&party=1337&size=5";
-                string expectedNext = $"https://platform.localhost:5080/events/api/v1/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337&size=5";
+                string expectedNext = $"http://localhost:5080/events/api/v1/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337&size=5";
 
                 int expectedCount = 2;
 
@@ -711,7 +711,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app/party?from=2020-01-01Z&size=5";
-                string expectedNext = $"https://platform.localhost:5080/events/api/v1/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&size=5";
+                string expectedNext = $"http://localhost:5080/events/api/v1/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&size=5";
 
                 int expectedCount = 2;
 
@@ -746,7 +746,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c7708&from=2020-01-01Z&party=1337&size=5";
-                string expectedNext = $"https://platform.localhost:5080/events/api/v1/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337&size=5";
+                string expectedNext = $"http://localhost:5080/events/api/v1/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337&size=5";
 
                 int expectedCount = 1;
 
@@ -779,7 +779,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/app/party?from=2020-01-01Z&party=1337&org=ttd&app=endring-av-navn-v2&size=5";
-                string expectedNext = $"https://platform.localhost:5080/events/api/v1/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337&org=ttd&app=endring-av-navn-v2&size=5";
+                string expectedNext = $"http://localhost:5080/events/api/v1/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c8808&from=2020-01-01Z&party=1337&org=ttd&app=endring-av-navn-v2&size=5";
 
                 int expectedCount = 2;
 

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/EventsControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/EventsControllerTests.cs
@@ -151,7 +151,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 // Act
                 HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
                 string content = await response.Content.ReadAsStringAsync();
-                ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content);
+                ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -170,7 +170,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             public async void GetEvents_MissingBearerToken_ReturnsUnauthorized()
             {
                 // Arrange
-                string requestUri = $"{BasePath}/events?subject=%2Fparty%2F1337";
+                string requestUri = $"{BasePath}/events?after=0&subject=%2Fparty%2F1337";
                 HttpClient client = GetTestClient(new Mock<IEventsService>().Object);
 
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
@@ -287,7 +287,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 // Arrange   
                 string expected = "The 'after' parameter must be defined.";
 
-                string requestUri = $"{BasePath}/events?size=5";
+                string requestUri = $"{BasePath}/events?size=5&subject=/party/1337";
                 HttpClient client = GetTestClient(new Mock<IEventsService>().Object);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events.subscribe"));
 

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/EventsControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/EventsControllerTests.cs
@@ -195,7 +195,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/events?source=urn:altinn:systemx&after=0&subject=%2Fparty%2F1337";
-                string expectedNext = $"https://platform.localhost:5080/events/api/v1/events?after=e31dbb11-2208-4dda-a549-92a0db8c8808&source=urn:altinn:systemx&subject=/party/1337";
+                string expectedNext = $"http://localhost:5080/events/api/v1/events?after=e31dbb11-2208-4dda-a549-92a0db8c8808&source=urn:altinn:systemx&subject=/party/1337";
                 int expectedCount = 2;
 
                 HttpClient client = GetTestClient(new EventsServiceMock(3));
@@ -210,7 +210,6 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                Assert.Equal(expectedCount, actual.Count);
                 Assert.Equal(expectedNext, response.Headers.GetValues("next").First());
             }
 
@@ -227,7 +226,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/events?source=urn:altinn:systemx&after=e31dbb11-2208-4dda-a549-92a0db8c7708&subject=/party/1337";
-                string expectedNext = $"https://platform.localhost:5080/events/api/v1/events?after=e31dbb11-2208-4dda-a549-92a0db8c8808&source=urn:altinn:systemx&subject=/party/1337";
+                string expectedNext = $"http://localhost:5080/events/api/v1/events?after=e31dbb11-2208-4dda-a549-92a0db8c8808&source=urn:altinn:systemx&subject=/party/1337";
                 int expectedCount = 1;
 
                 HttpClient client = GetTestClient(new EventsServiceMock(3));

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/EventsControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/EventsControllerTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -20,7 +22,7 @@ using Altinn.Platform.Events.UnitTest.Mocks;
 using AltinnCore.Authentication.JwtCookie;
 
 using CloudNative.CloudEvents;
-
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +32,7 @@ using Microsoft.IdentityModel.Logging;
 using Moq;
 
 using Xunit;
+using static Microsoft.Azure.KeyVault.WebKey.JsonWebKeyVerifier;
 
 namespace Altinn.Platform.Events.Tests.TestingControllers
 {
@@ -43,6 +46,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             private const string BasePath = "/events/api/v1";
 
             private readonly WebApplicationFactory<EventsController> _factory;
+            private readonly JsonSerializerOptions _options;
             private readonly CloudEvent _validEvent;
 
             /// <summary>
@@ -60,6 +64,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                     Subject = "/person/16069412345",
                     Source = new Uri("urn:isbn:1234567890"),
                 };
+                _options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
             }
 
             [Fact]
@@ -121,6 +126,181 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
                 // Assert
                 Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            }
+
+            /// <summary>
+            /// Scenario:
+            ///   Get events with negative size.
+            /// Expected result:
+            ///   Returns HttpStatus BadRequest.
+            /// Success criteria:
+            ///   The response has correct status.
+            /// </summary>
+            [Fact]
+            public async void GetEvents_SizeIsLessThanZero_ReturnsBadRequest()
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/events?size=-5&after=e31dbb11-2208-4dda-a549-92a0db8c8808";
+                string expected = "The 'size' parameter must be a number larger that 0.";
+
+                HttpClient client = GetTestClient(new Mock<IEventsService>().Object);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events.subscribe"));
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                string content = await response.Content.ReadAsStringAsync();
+                ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                Assert.Equal(expected, actual.Detail);
+            }
+
+            /// <summary>
+            /// Scenario:
+            ///   Retrieve a list of events, without bearer token.
+            /// Expected result:
+            ///   Returns HttpStatus Unauthorized.
+            /// Success criteria:
+            ///   The response has correct status.
+            /// </summary>
+            [Fact]
+            public async void GetEvents_MissingBearerToken_ReturnsUnauthorized()
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/events?subject=%2Fparty%2F1337";
+                HttpClient client = GetTestClient(new Mock<IEventsService>().Object);
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            }
+
+            /// <summary>
+            /// Scenario:
+            ///   Get events with  a valid set of query parameters
+            /// Expected result:
+            ///   Returns a list of events and a next header
+            /// Success criteria:
+            ///   The response has correct count. Next header is corrcect.
+            /// </summary>
+            [Fact]
+            public async void GetEvents_ValidRequest_ReturnsListOfEventsAndNextUrl()
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/events?after=0&subject=%2Fparty%2F1337";
+                string expectedNext = $"https://platform.localhost:5080/events/api/v1/events?after=e31dbb11-2208-4dda-a549-92a0db8c8808&subject=/party/1337";
+                int expectedCount = 2;
+
+                HttpClient client = GetTestClient(new EventsServiceMock(1));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events.subscribe"));
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                string responseString = await response.Content.ReadAsStringAsync();
+                List<CloudEvent> actual = JsonSerializer.Deserialize<List<CloudEvent>>(responseString);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(expectedCount, actual.Count);
+                Assert.Equal(expectedNext, response.Headers.GetValues("next").First());
+            }
+
+            /// <summary>
+            /// Scenario:
+            ///   TTD org Get events with  a valid set of query parameters
+            /// Expected result:
+            ///   Returns a list of events and a next header
+            /// Success criteria:
+            ///   The response has correct count. Next header is corrcect.
+            /// </summary>
+            [Fact]
+            public async void GetEvents_ValidRequest_ReturnsNextHeaderWithReplacesAfterParameter()
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/events?after=e31dbb11-2208-4dda-a549-92a0db8c7708&subject=/party/1337";
+                string expectedNext = $"https://platform.localhost:5080/events/api/v1/events?after=e31dbb11-2208-4dda-a549-92a0db8c8808&subject=/party/1337";
+                int expectedCount = 1;
+
+                HttpClient client = GetTestClient(new EventsServiceMock(1));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events.subscribe"));
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                string responseString = await response.Content.ReadAsStringAsync();
+                var actual = JsonSerializer.Deserialize<List<object>>(responseString);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(expectedCount, actual.Count);
+                Assert.Equal(expectedNext, response.Headers.GetValues("next").First());
+            }
+
+            /// <summary>
+            /// Scenario:
+            ///   Get events events service throws exception.
+            /// Expected result:
+            ///   Next header contains new guid in after parameter
+            /// Success criteria:
+            ///   Next header is corrcect.
+            /// </summary>
+            [Fact]
+            public async void GetEvents_ServiceThrowsException_ReturnsInternalServerError()
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/events?after=e31dbb11-2208-4dda-a549-92a0db8c7708&subject=/party/567890";
+                Mock<IEventsService> eventsService = new Mock<IEventsService>();
+                eventsService.Setup(es => es.GetAppEvents(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<int>(), It.IsAny<List<string>>(), It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Throws(new Exception());
+                HttpClient client = GetTestClient(eventsService.Object);
+
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events.subscribe"));
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            }
+
+            /// <summary>
+            /// Scenario:
+            ///   Get events without defined after or from in query.
+            /// Expected result:
+            ///   Returns HttpStatus BadRequest.
+            /// Success criteria:
+            ///   The response has correct status.
+            /// </summary>
+            [Fact]
+            public async void GetEvents_MissingRequiredQueryParam_ReturnsBadRequest()
+            {
+                // Arrange   
+                string expected = "The 'after' parameter must be defined.";
+
+                string requestUri = $"{BasePath}/events?size=5";
+                HttpClient client = GetTestClient(new Mock<IEventsService>().Object);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events.subscribe"));
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                string content = await response.Content.ReadAsStringAsync();
+                ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                Assert.Equal(expected, actual.Detail);
             }
 
             [Fact]

--- a/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
@@ -379,8 +379,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             List<CloudEvent> actual = await eventsService.GetEvents("1", new List<string>() { "https://ttd.apps.at22.altinn.cloud/ttd/app-test/" }, new List<string>() { }, null);
 
             // Assert
-            registerMock.Verify(r => r.PartyLookup(It.Is<string>(s => string.IsNullOrEmpty(s)), It.Is<string>(s => string.IsNullOrEmpty(s))), Times.Never);
-        }
+            registerMock.Verify(r => r.PartyLookup(It.IsAny<string>(), It.IsAny<string>()), Times.Never);        }
 
         #endregion
 

--- a/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
@@ -249,6 +249,141 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             registerMock.Verify(r => r.PartyLookup(It.Is<string>(s => string.IsNullOrEmpty(s)), It.Is<string>(s => string.IsNullOrEmpty(s))), Times.Never);
         }
 
+        #region Generic events
+
+        /// <summary>
+        /// Scenario:
+        ///   Get instances based on from and party Id
+        /// Expected result:
+        ///   A single instance is returned.
+        /// Success criteria:
+        ///  PartyId is coverted to correct subject and matched in the repository.
+        /// </summary>
+        [Fact]
+        public async Task GetEvents_QueryIncludesAfterAndSubject_RetrievesCorrectNumberOfEvents()
+        {
+            // Arrange
+            int expectedCount = 1;
+            string expectedSubject = "/party/54321";
+
+            EventsService eventsService = GetEventsService(repositoryMock: new CloudEventRepositoryMock(2));
+
+            // Act
+            List<CloudEvent> actual = await eventsService.GetEvents("e31dbb11-2208-4dda-a549-92a0db8c0008", new List<string>() { }, new List<string>() { }, expectedSubject);
+
+            // Assert
+            Assert.Equal(expectedCount, actual.Count);
+            Assert.Equal(expectedSubject, actual.First().Subject);
+        }
+
+        /// <summary>
+        /// Scenario:
+        ///   Get instances based on after.
+        /// Expected result:
+        ///   A single instance is returned.
+        /// Success criteria:
+        ///  Passes on the after parameter to the repository.
+        /// </summary>
+        [Fact]
+        public async Task GetEvents_QueryIncludesAfter_RetrievesCorrectNumberOfEvents()
+        {
+            // Arrange
+            int expectedCount = 3;
+            EventsService eventsService = GetEventsService(repositoryMock: new CloudEventRepositoryMock(2));
+
+            // Act
+            List<CloudEvent> actual = await eventsService.GetEvents("e31dbb11-2208-4dda-a549-92a0db8c8808", new List<string>() { }, new List<string>() { }, null);
+
+            // Assert
+            Assert.Equal(expectedCount, actual.Count);
+        }
+
+        /// <summary>
+        /// Scenario:
+        ///   Get instances with various input 
+        /// Expected result:
+        ///   Conditions to evaluate input to repository method are evaluated.
+        /// Success criteria:
+        ///  Conditions are evaluated correctly.
+        /// </summary>
+        [Fact]
+        public async Task GetEvents_AllConditionsHaveValues_ConditionsEvaluatedCorrectly()
+        {
+            // Arrange
+            string expectedSubject = "/party/50";
+            var repositoryMock = new Mock<ICloudEventRepository>();
+            repositoryMock.Setup(r => r.GetEvents(
+                It.IsAny<string>(), // after
+                It.Is<List<string>>(sourceFilter => sourceFilter != null),
+                It.Is<List<string>>(typeFiler => typeFiler != null),
+                It.Is<string>(subject => subject.Equals(subject)),
+                It.IsAny<int>())) // size
+                .ReturnsAsync(new List<CloudEvent>());
+
+            EventsService eventsService = GetEventsService(repositoryMock: repositoryMock.Object);
+
+            // Act
+            List<CloudEvent> actual = await eventsService.GetEvents(null, new List<string>() { "https://ttd.apps.tt02.altinn.no/ttd/apps-test/" }, new List<string>() { "instance.completed" }, expectedSubject);
+
+            // Assert
+            repositoryMock.VerifyAll();
+        }
+
+        /// <summary>
+        /// Scenario:
+        ///   Get instances with various input 
+        /// Expected result:
+        ///   Conditions to evaluate input to repository method are evaluated.
+        /// Success criteria:
+        ///  Conditions are evaluated correctly.
+        /// </summary>
+        [Fact]
+        public async Task GetEvents_AllConditionsAreNull_ConditionsEvaluatedCorrectly()
+        {
+            // Arrange
+            var repositoryMock = new Mock<ICloudEventRepository>();
+            repositoryMock.Setup(r => r.GetEvents(
+                It.IsAny<string>(), // after
+                null, // sourceFilter
+                null, // typeFilter
+                string.Empty, // subject
+                It.IsAny<int>())) // size
+                .ReturnsAsync(new List<CloudEvent>());
+
+            EventsService eventsService = GetEventsService(repositoryMock: repositoryMock.Object);
+
+            // Act
+            List<CloudEvent> actual = await eventsService.GetEvents(null, new List<string>(), new List<string>(), string.Empty);
+
+            // Assert
+            repositoryMock.VerifyAll();
+        }
+
+        /// <summary>
+        /// Scenario:
+        ///   Get instances without specifying source
+        /// Expected result:
+        ///   No events are returned
+        /// Success criteria:
+        ///  Register service is not called to lookup party
+        /// </summary>
+        [Fact]
+        public async Task GetEvents_NoSubjectInfoAvailable_RegisterLookupIsNotCalled()
+        {
+            // Arrange
+            Mock<IRegisterService> registerMock = new();
+
+            EventsService eventsService = GetEventsService(registerMock: registerMock);
+
+            // Act
+            List<CloudEvent> actual = await eventsService.GetEvents("1", new List<string>() { "https://ttd.apps.at22.altinn.cloud/ttd/app-test/" }, new List<string>() { }, null);
+
+            // Assert
+            registerMock.Verify(r => r.PartyLookup(It.Is<string>(s => string.IsNullOrEmpty(s)), It.Is<string>(s => string.IsNullOrEmpty(s))), Times.Never);
+        }
+
+        #endregion
+
         /// <summary>
         /// Scenario:
         ///   Save a CloudEvent from an Altinn App in postgres DB.

--- a/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
@@ -116,9 +116,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances based on from and party Id
+        ///   Get events based on from and party Id
         /// Expected result:
-        ///   A single instance is returned.
+        ///   A single event is returned.
         /// Success criteria:
         ///  PartyId is coverted to correct subject and matched in the repository.
         /// </summary>
@@ -141,9 +141,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances based on after.
+        ///   Get events based on after.
         /// Expected result:
-        ///   A single instance is returned.
+        ///   A single event is returned.
         /// Success criteria:
         ///  Passes on the after parameter to the repository.
         /// </summary>
@@ -163,7 +163,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances with various input 
+        ///   Get events with various input 
         /// Expected result:
         ///   Conditions to evaluate input to repository method are evaluated.
         /// Success criteria:
@@ -196,7 +196,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances with various input 
+        ///   Get events with various input 
         /// Expected result:
         ///   Conditions to evaluate input to repository method are evaluated.
         /// Success criteria:
@@ -228,7 +228,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances without specifying source
+        ///   Get events without specifying source
         /// Expected result:
         ///   No events are returned
         /// Success criteria:
@@ -253,9 +253,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances based on after and party Id
+        ///   Get events based on after and party Id
         /// Expected result:
-        ///   A single instance is returned.
+        ///   A single event is returned.
         /// Success criteria:
         ///  PartyId is coverted to correct subject and matched in the repository.
         /// </summary>
@@ -278,9 +278,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances based on after.
+        ///   Get events based on after.
         /// Expected result:
-        ///   A single instance is returned.
+        ///   A single event is returned.
         /// Success criteria:
         ///  Passes on the after parameter to the repository.
         /// </summary>
@@ -300,7 +300,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances with various input 
+        ///   Get events with various input 
         /// Expected result:
         ///   Conditions to evaluate input to repository method are evaluated.
         /// Success criteria:
@@ -331,7 +331,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances with various input 
+        ///   Get events with various input 
         /// Expected result:
         ///   Conditions to evaluate input to repository method are evaluated.
         /// Success criteria:
@@ -361,7 +361,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances without specifying source
+        ///   Get events without specifying source
         /// Expected result:
         ///   No events are returned
         /// Success criteria:

--- a/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
@@ -379,7 +379,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             List<CloudEvent> actual = await eventsService.GetEvents("1", new List<string>() { "https://ttd.apps.at22.altinn.cloud/ttd/app-test/" }, new List<string>() { }, null);
 
             // Assert
-            registerMock.Verify(r => r.PartyLookup(It.IsAny<string>(), It.IsAny<string>()), Times.Never);        }
+            registerMock.Verify(r => r.PartyLookup(It.IsAny<string>(), It.IsAny<string>()), Times.Never);        
+        }
 
         #endregion
 

--- a/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
@@ -269,7 +269,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             EventsService eventsService = GetEventsService(repositoryMock: new CloudEventRepositoryMock(2));
 
             // Act
-            List<CloudEvent> actual = await eventsService.GetEvents("e31dbb11-2208-4dda-a549-92a0db8c0008", new List<string>() { }, new List<string>() { }, expectedSubject);
+            List<CloudEvent> actual = await eventsService.GetEvents("e31dbb11-2208-4dda-a549-92a0db8c0008", new List<string>() { }, new List<string>() { }, expectedSubject, 50);
 
             // Assert
             Assert.Equal(expectedCount, actual.Count);
@@ -292,7 +292,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             EventsService eventsService = GetEventsService(repositoryMock: new CloudEventRepositoryMock(2));
 
             // Act
-            List<CloudEvent> actual = await eventsService.GetEvents("e31dbb11-2208-4dda-a549-92a0db8c8808", new List<string>() { }, new List<string>() { }, null);
+            List<CloudEvent> actual = await eventsService.GetEvents("e31dbb11-2208-4dda-a549-92a0db8c8808", new List<string>() { }, new List<string>() { }, null, 50);
 
             // Assert
             Assert.Equal(expectedCount, actual.Count);
@@ -323,7 +323,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             EventsService eventsService = GetEventsService(repositoryMock: repositoryMock.Object);
 
             // Act
-            List<CloudEvent> actual = await eventsService.GetEvents(null, new List<string>() { "https://ttd.apps.tt02.altinn.no/ttd/apps-test/" }, new List<string>() { "instance.completed" }, expectedSubject);
+            List<CloudEvent> actual = await eventsService.GetEvents(null, new List<string>() { "https://ttd.apps.tt02.altinn.no/ttd/apps-test/" }, new List<string>() { "instance.completed" }, expectedSubject, 50);
 
             // Assert
             repositoryMock.VerifyAll();
@@ -353,7 +353,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             EventsService eventsService = GetEventsService(repositoryMock: repositoryMock.Object);
 
             // Act
-            List<CloudEvent> actual = await eventsService.GetEvents(null, new List<string>(), new List<string>(), string.Empty);
+            List<CloudEvent> actual = await eventsService.GetEvents(null, new List<string>(), new List<string>(), string.Empty, 50);
 
             // Assert
             repositoryMock.VerifyAll();
@@ -376,7 +376,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             EventsService eventsService = GetEventsService(registerMock: registerMock);
 
             // Act
-            List<CloudEvent> actual = await eventsService.GetEvents("1", new List<string>() { "https://ttd.apps.at22.altinn.cloud/ttd/app-test/" }, new List<string>() { }, null);
+            List<CloudEvent> actual = await eventsService.GetEvents("1", new List<string>() { "https://ttd.apps.at22.altinn.cloud/ttd/app-test/" }, new List<string>() { }, null, 50);
 
             // Assert
             registerMock.Verify(r => r.PartyLookup(It.IsAny<string>(), It.IsAny<string>()), Times.Never);        

--- a/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/EventsServiceTest.cs
@@ -253,7 +253,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
         /// <summary>
         /// Scenario:
-        ///   Get instances based on from and party Id
+        ///   Get instances based on after and party Id
         /// Expected result:
         ///   A single instance is returned.
         /// Success criteria:

--- a/test/Altinn.Platform.Events.Tests/appsettings.json
+++ b/test/Altinn.Platform.Events.Tests/appsettings.json
@@ -3,7 +3,7 @@
     "EnableDBConnection": "false"
   },
   "GeneralSettings": {
-    "Hostname": "localhost:5080",
+    "BaseUri": "https://platform.localhost:5080",
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "JwtCookieName": "AltinnStudioRuntime"
   },

--- a/test/Altinn.Platform.Events.Tests/appsettings.json
+++ b/test/Altinn.Platform.Events.Tests/appsettings.json
@@ -3,7 +3,7 @@
     "EnableDBConnection": "false"
   },
   "GeneralSettings": {
-    "BaseUri": "https://platform.localhost:5080",
+    "BaseUri": "http://localhost:5080",
     "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "JwtCookieName": "AltinnStudioRuntime"
   },

--- a/test/k6/readme.md
+++ b/test/k6/readme.md
@@ -33,13 +33,13 @@ Run test suite by specifying filename.
 
 For example:
 
->$> docker-compose run k6 run /src/tests/events.js -e tokenGeneratorUserName=*** -e tokenGeneratorUserPwd=*** -e env=***
+>$> docker-compose run k6 run /src/tests/events/post.js -e tokenGeneratorUserName=*** -e tokenGeneratorUserPwd=*** -e env=***
 
 The comand consists of three sections
 
 `docker-compose run` to run the test in a docker container
 
-`k6 run {path to test file}` pointing to the test file you want to run e.g. `/src/tests/events.js`
+`k6 run {path to test file}` pointing to the test file you want to run e.g. `/src/tests/events/post.js`
 
 
 `-e tokenGeneratorUserName=*** -e tokenGeneratorUserPwd=*** -e env=***` all environment variables that should be included in the request.

--- a/test/k6/src/api/events.js
+++ b/test/k6/src/api/events.js
@@ -16,3 +16,16 @@ export function postCloudEvent(serializedCloudEvent, token) {
 
   return response;
 }
+
+export function getCloudEvents(token) {
+  var endpoint = config.platformEvents.events;
+
+  var params = apiHelpers.buildHeaderWithBearerAndContentType(
+    token,
+    "application/cloudevents+json"
+  );
+
+  var response = http.get(endpoint, params);
+
+  return response;
+}

--- a/test/k6/src/api/events.js
+++ b/test/k6/src/api/events.js
@@ -7,7 +7,7 @@ import * as apiHelpers from "../apiHelpers.js";
 export function postCloudEvent(serializedCloudEvent, token) {
   var endpoint = config.platformEvents.events;
 
-  var params = apiHelpers.buildHeaderWithBearerAndContentType(
+  var params = apiHelpers.buildHeaderWithBearerContentTypeAndQuery(
     token,
     "application/cloudevents+json"
   );
@@ -17,12 +17,19 @@ export function postCloudEvent(serializedCloudEvent, token) {
   return response;
 }
 
-export function getCloudEvents(token) {
+export function getCloudEvents(after, source, type, subject, size, token) {
   var endpoint = config.platformEvents.events;
 
-  var params = apiHelpers.buildHeaderWithBearerAndContentType(
+  var params = apiHelpers.buildHeaderWithBearerContentTypeAndQuery(
     token,
-    "application/cloudevents+json"
+    "application/cloudevents+json",
+    {
+      after,
+      source,
+      type,
+      subject,
+      size
+    }
   );
 
   var response = http.get(endpoint, params);

--- a/test/k6/src/apiHelpers.js
+++ b/test/k6/src/apiHelpers.js
@@ -39,13 +39,14 @@ export function buildHeaderWithBasic(token){
     return params;
 }
 
-export function buildHeaderWithBearerAndContentType(token, conentType) {
+export function buildHeaderWithBearerContentTypeAndQuery(token, conentType, query) {
   var params = {
     headers: {
       Authorization: "Bearer " + token,
       "Content-Type": conentType
-    }
+    },
+    query,
   };
-
+ 
   return params;
 }

--- a/test/k6/src/tests/events/get.js
+++ b/test/k6/src/tests/events/get.js
@@ -1,7 +1,7 @@
 /*
     Test script to platform events api with user token
     Command:
-    docker-compose run k6 run /src/tests/events.js `
+    docker-compose run k6 run /src/tests/events/post.js `
     -e tokenGeneratorUserName=autotest `
     -e tokenGeneratorUserPwd=*** `
     -e env=*** `

--- a/test/k6/src/tests/events/get.js
+++ b/test/k6/src/tests/events/get.js
@@ -51,9 +51,11 @@ function TC01_GetAllEvents(data) {
     data.token
   );
 
+
   success = check(response, {
-    "GET all cloud events. Status is 200": (r) =>
-      r.status === 200,
+    "GET all cloud events: status is 200": (r) => r.status === 200,
+    "GET all cloud events: at least 1 cloud event returned": (r) =>
+      Array.isArray(r.data) && r.data.length >= 1
   });
 
   addErrorCount(success);
@@ -71,20 +73,3 @@ export default function (data) {
     TC01_GetAllEvents(data);
   }
 }
-
-function removePropFromCloudEvent(cloudEvent, propertyname) {
-  // parse and stringify to ensure a copy of the object by value not ref
-  var modifiedEvent = JSON.parse(JSON.stringify(cloudEvent));
-  delete modifiedEvent[propertyname];
-
-  return modifiedEvent;
-}
-
-/*
-export function handleSummary(data) {
-  let result = {};
-  result[reportPath("events.xml")] = generateJUnitXML(data, "events");
-
-  return result;
-}
-*/

--- a/test/k6/src/tests/events/get.js
+++ b/test/k6/src/tests/events/get.js
@@ -37,7 +37,7 @@ export function setup() {
   return data;
 }
 
-// 01 - POST valid cloud event with all parameters
+// 01 - GET the first 10 cloud events published
 function TC01_GetAllEvents(data) {
   var response, success;
 

--- a/test/k6/src/tests/events/get.js
+++ b/test/k6/src/tests/events/get.js
@@ -1,0 +1,100 @@
+/*
+    Test script to platform events api with user token
+    Command:
+    docker-compose run k6 run /src/tests/events.js `
+    -e tokenGeneratorUserName=autotest `
+    -e tokenGeneratorUserPwd=*** `
+    -e env=*** `
+    -e runFullTestSet=true
+
+    For use case tests omit environment variable runFullTestSet or set value to false
+*/
+import { check } from "k6";
+import * as setupToken from "../../setup.js";
+import * as eventsApi from "../../api/events.js";
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+const eventJson = JSON.parse(open("../../data/events/01-event.json"));
+import { generateJUnitXML, reportPath } from "../../report.js";
+import { addErrorCount } from "../../errorhandler.js";
+const scopes = "altinn:events.subscribe";
+
+export function setup() {
+  var token = setupToken.getAltinnTokenForOrg(scopes);
+
+  var cloudEvent = eventJson;
+  cloudEvent.id = uuidv4();
+
+  const runFullTestSet = __ENV.runFullTestSet
+    ? __ENV.runFullTestSet.toLowerCase().includes("true")
+    : false;
+
+  var data = {
+    runFullTestSet: runFullTestSet,
+    token: token,
+    cloudEvent: cloudEvent,
+  };
+
+  return data;
+}
+
+// 01 - POST valid cloud event with all parameters
+function TC01_GetAllEvents(data) {
+  var response, success;
+
+  response = eventsApi.postCloudEvent(
+    JSON.stringify(data.cloudEvent),
+    data.token
+  );
+
+  success = check(response, {
+    "POST valid cloud event with all parameters. Status is 200": (r) =>
+      r.status === 200,
+  });
+
+  addErrorCount(success);
+
+  response = eventsApi.getCloudEvents("0", 
+    data.cloudEvent.source,
+    data.cloudEvent.type,
+    data.cloudEvent.subject,
+    10,
+    data.token
+  );
+
+  success = check(response, {
+    "GET all cloud events. Status is 200": (r) =>
+      r.status === 200,
+  });
+
+  addErrorCount(success);
+}
+
+/*
+ * 01 - GET all existing cloud events for subject /party/1337
+ */
+export default function (data) {
+  if (data.runFullTestSet) {
+    TC01_GetAllEvents(data);
+    
+  } else {
+    // Limited test set for use case tests
+    TC01_GetAllEvents(data);
+  }
+}
+
+function removePropFromCloudEvent(cloudEvent, propertyname) {
+  // parse and stringify to ensure a copy of the object by value not ref
+  var modifiedEvent = JSON.parse(JSON.stringify(cloudEvent));
+  delete modifiedEvent[propertyname];
+
+  return modifiedEvent;
+}
+
+/*
+export function handleSummary(data) {
+  let result = {};
+  result[reportPath("events.xml")] = generateJUnitXML(data, "events");
+
+  return result;
+}
+*/

--- a/test/k6/src/tests/events/get.js
+++ b/test/k6/src/tests/events/get.js
@@ -9,7 +9,7 @@
 
     For use case tests omit environment variable runFullTestSet or set value to false
 */
-import { check } from "k6";
+import { check, sleep } from "k6";
 import * as setupToken from "../../setup.js";
 import * as eventsApi from "../../api/events.js";
 import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
@@ -41,17 +41,7 @@ export function setup() {
 function TC01_GetAllEvents(data) {
   var response, success;
 
-  response = eventsApi.postCloudEvent(
-    JSON.stringify(data.cloudEvent),
-    data.token
-  );
-
-  success = check(response, {
-    "POST valid cloud event with all parameters. Status is 200": (r) =>
-      r.status === 200,
-  });
-
-  addErrorCount(success);
+  // we assume that /events/post.js has run at least once, publishing several events
 
   response = eventsApi.getCloudEvents("0", 
     data.cloudEvent.source,

--- a/test/k6/src/tests/events/post.js
+++ b/test/k6/src/tests/events/post.js
@@ -13,7 +13,7 @@ import { check } from "k6";
 import * as setupToken from "../../setup.js";
 import * as eventsApi from "../../api/events.js";
 import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
-const eventJson = JSON.parse(open("../data/events/01-event.json"));
+const eventJson = JSON.parse(open("../../data/events/01-event.json"));
 import { generateJUnitXML, reportPath } from "../../report.js";
 import { addErrorCount } from "../../errorhandler.js";
 const scopes = "altinn:events.publish";

--- a/test/k6/src/tests/events/post.js
+++ b/test/k6/src/tests/events/post.js
@@ -1,7 +1,7 @@
 /*
     Test script to platform events api with user token
     Command:
-    docker-compose run k6 run /src/tests/events.js `
+    docker-compose run k6 run /src/tests/events/post.js `
     -e tokenGeneratorUserName=autotest `
     -e tokenGeneratorUserPwd=*** `
     -e env=*** `

--- a/test/k6/src/tests/events/post.js
+++ b/test/k6/src/tests/events/post.js
@@ -10,12 +10,12 @@
     For use case tests omit environment variable runFullTestSet or set value to false
 */
 import { check } from "k6";
-import * as setupToken from "../setup.js";
-import * as eventsApi from "../api/events.js";
+import * as setupToken from "../../setup.js";
+import * as eventsApi from "../../api/events.js";
 import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 const eventJson = JSON.parse(open("../data/events/01-event.json"));
-import { generateJUnitXML, reportPath } from "../report.js";
-import { addErrorCount } from "../errorhandler.js";
+import { generateJUnitXML, reportPath } from "../../report.js";
+import { addErrorCount } from "../../errorhandler.js";
 const scopes = "altinn:events.publish";
 
 export function setup() {


### PR DESCRIPTION
Added new endpoint for retrieving cloud events from the events database (Postgresql).

## Description
Migrated existing functionality from App Events and refactored to support generic cloud events.

## Related Issue(s)
- #108 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated - see `feature/events` branch in the `altinn-studio-docs` repo.