### PR TITLE
Workflow not failing if k6 fails

### DIFF
--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -22,7 +22,6 @@ jobs:
     - name: Run events use case tests
       run:  |
               cd test/k6
-
               docker-compose run k6 run /src/tests/events/post.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
               docker-compose run k6 run /src/tests/events/get.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
     - name: Run subscription use case tests
@@ -47,4 +46,4 @@ jobs:
             }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_TEST }}
-
+    

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -2,6 +2,9 @@ name: Use Case - AT
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
   schedule:
   - cron: '*/15 * * * *'
 

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -2,9 +2,6 @@ name: Use Case - AT
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
   schedule:
   - cron: '*/15 * * * *'
 
@@ -25,7 +22,7 @@ jobs:
     - name: Run events use case tests
       run:  |
               cd test/k6
-              set -e
+
               docker-compose run k6 run /src/tests/events/post.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
               docker-compose run k6 run /src/tests/events/get.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
     - name: Run subscription use case tests

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -22,6 +22,7 @@ jobs:
     - name: Run events use case tests
       run:  |
               cd test/k6
+              set -e
               docker-compose run k6 run /src/tests/events/post.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
               docker-compose run k6 run /src/tests/events/get.js -e env=${{ vars.ENV }} -e tokenGeneratorUserName=${{ secrets.TOKENGENERATOR_USERNAME }} -e tokenGeneratorUserPwd=${{ secrets.TOKENGENERATOR_USERPASSWORD }}
     - name: Run subscription use case tests
@@ -46,4 +47,4 @@ jobs:
             }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_TEST }}
-    
+

--- a/test/k6/src/tests/events/get.js
+++ b/test/k6/src/tests/events/get.js
@@ -15,7 +15,7 @@ import * as eventsApi from "../../api/events.js";
 import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 const eventJson = JSON.parse(open("../../data/events/01-event.json"));
 import { generateJUnitXML, reportPath } from "../../report.js";
-import { addErrorCount } from "../../errorhandler.js";
+import { addErrorCount, stopIterationOnFail } from "../../errorhandler.js";
 const scopes = "altinn:events.subscribe";
 
 export const options = {
@@ -62,11 +62,17 @@ function TC01_GetAllEvents(data) {
 
   success = check(response, {
     "GET all cloud events: status is 200": (r) => r.status === 200,
-    "GET all cloud events: at least 1 cloud event returned": (r) =>
-    {
+  });
+  addErrorCount(success);
+
+  // only continue to parse and check content if success response code
+  stopIterationOnFail(success);
+
+  success = check(response, {
+    "GET all cloud events: at least 1 cloud event returned": (r) => {
       var responseBody = JSON.parse(r.body);
       return Array.isArray(responseBody) && responseBody.length >= 1;
-    }
+    },
   });
 
   addErrorCount(success);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use case tests for AT have been failing for quite some time due to bad testdata, but workflow has been running green. Fixed issue in test where serialization issue stopped the error from being registered in the k6 results.

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
