### PR TITLE
Revert removal of dependency to JWTCookieAuthentication

### DIFF
--- a/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
+++ b/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.5.1" />
     <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.6.0" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.6.0" />
-    <PackageReference Include="JWTCookieAuthentication" Version="3.0.0" />
+    <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.2" />

--- a/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
+++ b/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
@@ -11,12 +11,11 @@
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.5.1" />
     <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.6.0" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="JWTCookieAuthentication" Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.1.2" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.30.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description
Revert removal of dependency to JWTCookieAuthentication. 
Remove direct dependency to Microsoft.IdentityModel.Tokens. This is included through JWTCookieAuthentication and was causing version issues.

