### PR TITLE
Increase query performance on GET

### DIFF
--- a/src/Events/Migration/v0.32/01-new-indexes.sql
+++ b/src/Events/Migration/v0.32/01-new-indexes.sql
@@ -9,6 +9,8 @@ CREATE INDEX IF NOT EXISTS idx_events_cloudevent_source
     ON events.events ((cloudevent ->> 'source'));
 CREATE INDEX IF NOT EXISTS idx_events_cloudevent_type
     ON events.events ((cloudevent ->> 'type'));
+CREATE INDEX IF NOT EXISTS idx_events_cloudevent_time
+    ON events.events ((cloudevent ->> 'time'));
 
 -- Drop redundant GIN index
 DROP INDEX IF EXISTS events.idx_gin_events_computed_cloudevent;

--- a/src/Events/Migration/v0.32/01-new-indices.sql
+++ b/src/Events/Migration/v0.32/01-new-indices.sql
@@ -1,0 +1,14 @@
+--- Create B-tree indices on json columns
+CREATE INDEX IF NOT EXISTS idx_events_cloudevent_id
+    ON events.events ((cloudevent ->> 'id'));
+CREATE INDEX IF NOT EXISTS idx_events_cloudevent_subject
+    ON events.events ((cloudevent ->> 'subject'));
+CREATE INDEX IF NOT EXISTS idx_events_cloudevent_alternativesubject
+    ON events.events ((cloudevent ->> 'alternativesubject'));
+CREATE INDEX IF NOT EXISTS idx_events_cloudevent_source
+    ON events.events ((cloudevent ->> 'source'));
+CREATE INDEX IF NOT EXISTS idx_events_cloudevent_type
+    ON events.events ((cloudevent ->> 'type'));
+
+-- Drop redundant GIN index
+DROP INDEX IF EXISTS events.idx_gin_events_computed_cloudevent;

--- a/src/Events/Migration/v0.32/02-update-function.sql
+++ b/src/Events/Migration/v0.32/02-update-function.sql
@@ -58,7 +58,6 @@ CREATE OR REPLACE FUNCTION events.getevents(
 	_after character varying,
 	_type text[],
 	_source character varying,
-	_resource character varying,
 	_size integer)
     RETURNS TABLE(cloudevents text)
     LANGUAGE 'plpgsql'

--- a/src/Events/Migration/v0.32/02-update-function.sql
+++ b/src/Events/Migration/v0.32/02-update-function.sql
@@ -1,3 +1,53 @@
+DROP FUNCTION IF EXISTS events.getappevents(character varying, character varying, timestamp with time zone, timestamp with time zone, text[], text[], integer);
+CREATE OR REPLACE FUNCTION events.getappevents(
+	_subject character varying,
+	_after character varying,
+	_from timestamp with time zone,
+	_to timestamp with time zone,
+	_type text[],
+	_source text[],
+	_size integer)
+    RETURNS TABLE(cloudevents text)
+    LANGUAGE 'plpgsql'
+    --COST 100
+    --VOLATILE PARALLEL UNSAFE
+    ROWS 1000
+
+AS $BODY$
+DECLARE
+_sequenceno bigint;
+BEGIN
+IF _after IS NOT NULL AND _after <> '' THEN
+	SELECT
+		case count(*)
+		when 0
+			then 0
+		else
+			(SELECT sequenceno FROM events.events
+			WHERE cloudevent->>'id' = _after
+			ORDER BY sequenceno ASC)
+		end
+	INTO _sequenceno
+	FROM events.events
+	WHERE cloudevent->>'id' = _after;
+END IF;
+return query
+	SELECT cast(cloudevent as text) as cloudevents
+		FROM events.events
+		WHERE (_subject IS NULL OR cloudevent->>'subject' = _subject)
+			AND (_from IS NULL OR cloudevent->>'time' >= _from::text)
+			AND (_to IS NULL OR cloudevent->>'time' <= _to::text)
+			AND registeredtime <= now() - interval '30 second'
+			AND (_type IS NULL OR cloudevent->>'type' ILIKE ANY(_type))
+			AND (_source IS NULL OR cloudevent->>'source' ILIKE ANY(_source))
+			AND (_after IS NULL OR _after = '' OR sequenceno > _sequenceno)
+		ORDER BY sequenceno
+		limit _size;
+END;
+$BODY$;
+
+
+
 -- Changes:
 --  * Sets to STABLE PARALLEL SAFE
 --  * Changes ILIKE to LIKE for better index performance
@@ -17,9 +67,23 @@ CREATE OR REPLACE FUNCTION events.getevents(
     ROWS 1000
 
 AS $BODY$
-
-
+DECLARE
+_sequenceno bigint;
 BEGIN
+IF _after IS NOT NULL AND _after <> '' THEN
+	SELECT
+		case count(*)
+		when 0
+			then 0
+		else
+			(SELECT sequenceno FROM events.events
+			WHERE cloudevent->>'id' = _after
+			ORDER BY sequenceno ASC)
+		end
+	INTO _sequenceno
+	FROM events.events
+	WHERE cloudevent->>'id' = _after;
+END IF;
 return query
 	SELECT cast(cloudevent as text) as cloudevents
 	FROM events.events
@@ -28,20 +92,7 @@ return query
 	AND (_source IS NULL OR cloudevent->>'source' LIKE _source)
 	AND (_type IS NULL OR cloudevent->>'type' LIKE ANY(_type) )
 	AND registeredtime <= now() - interval '30 second'
-	AND (_after = '' OR sequenceno >(
-		SELECT
-			case count(*)
-			when 0
-				then 0
-			else
-				(SELECT sequenceno
-				FROM events.events
-				WHERE cloudevent->>'id' = _after
-				ORDER BY sequenceno ASC
-				LIMIT 1)
-			end
-		FROM events.events
-		WHERE cloudevent->>'id' = _after))
+	AND (_after IS NULL OR _after = '' OR sequenceno > _sequenceno)
   ORDER BY sequenceno
   limit _size;
 END;

--- a/src/Events/Migration/v0.32/02-update-function.sql
+++ b/src/Events/Migration/v0.32/02-update-function.sql
@@ -1,0 +1,48 @@
+-- Changes:
+--  * Sets to STABLE PARALLEL SAFE
+--  * Changes ILIKE to LIKE for better index performance
+
+CREATE OR REPLACE FUNCTION events.getevents(
+	_subject character varying,
+	_alternativesubject character varying,
+	_after character varying,
+	_type text[],
+	_source character varying,
+	_resource character varying,
+	_size integer)
+    RETURNS TABLE(cloudevents text)
+    LANGUAGE 'plpgsql'
+    COST 100
+    STABLE PARALLEL SAFE
+    ROWS 1000
+
+AS $BODY$
+
+
+BEGIN
+return query
+	SELECT cast(cloudevent as text) as cloudevents
+	FROM events.events
+	WHERE (_subject IS NULL OR cloudevent->>'subject' = _subject)
+	AND (_alternativeSubject IS NULL OR cloudevent->>'alternativesubject' = _alternativesubject)
+	AND (_source IS NULL OR cloudevent->>'source' LIKE _source)
+	AND (_type IS NULL OR cloudevent->>'type' LIKE ANY(_type) )
+	AND registeredtime <= now() - interval '30 second'
+	AND (_after = '' OR sequenceno >(
+		SELECT
+			case count(*)
+			when 0
+				then 0
+			else
+				(SELECT sequenceno
+				FROM events.events
+				WHERE cloudevent->>'id' = _after
+				ORDER BY sequenceno ASC
+				LIMIT 1)
+			end
+		FROM events.events
+		WHERE cloudevent->>'id' = _after))
+  ORDER BY sequenceno
+  limit _size;
+END;
+$BODY$;


### PR DESCRIPTION
This adds B-tree indices for queryable JSON columns and, adjusts function for improved query performance on generic events. 

## Description
The GIN index employed does not support  `cloudevent ->> 'id = ...` WHERE clauses, causing the `getevents` function to do sequential scans. This change:
* Drops the GIN index and adds B-tree indices for the columns that can be used for filtering.
* Replaces ILIKE with LIKE on the source-column, which helps index performance when querying (~20%). 
* Changes `VOLATILE PARALLEL UNSAFE` to `STABLE PARALLEL SAFE` to hint to Postgre that this is a pure function

Tests performed locally on 1.000.000 rows increases performance by an order of magnitude:

```sql
-- The table has 1.000.000 randomized entries, with a UUID after '/dialogs/', 
-- so a match for '/ab%' here will hit rows all over the table
SELECT * FROM events.getevents(
    _subject := NULL, 
    _alternativesubject := NULL, 
    _after := '0', 
    _type := NULL, 
    _source := 'https://dialogporten.no/api/v1/dialogs/ab%', 
    _size := 30
);
-- Query response times are reduced on my computer from ~500ms to ~50ms
```

Write performance appears to be slightly worse compared to the GIN index; a prepared INSERT statement called in a tight loop is reduced from ~1800 inserts/sec to ~1600 inserts/sec on my computer.

## Note! 
* The `CREATE INDEX` statements takes about ~90 seconds on my computer on 1.000.000 rows. 
* Changing `ILIKE` to `LIKE` might cause subscriptions/queries to no longer match anything


## Related Issue(s)
N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green