### PR TITLE
Add administrative publishing scope short circuiting authorization

### DIFF
--- a/src/Events/Configuration/AuthorizationConstants.cs
+++ b/src/Events/Configuration/AuthorizationConstants.cs
@@ -36,6 +36,11 @@
         public const string SCOPE_EVENTS_SUBSCRIBE = "altinn:events.subscribe";
 
         /// <summary>
+        /// Scope for allowing administrators to publish events without Altinn Authorization
+        /// </summary>
+        public const string SCOPE_EVENTS_ADMIN_PUBLISH = "altinn:events.publish.admin";
+
+        /// <summary>
         /// The urn prefix for Altinn App resources
         /// </summary>
         public const string AppResourcePrefix = "urn:altinn:resource:altinnapp.";

--- a/src/Events/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Events/Extensions/ClaimsPrincipalExtensions.cs
@@ -50,14 +50,14 @@ namespace Altinn.Platorm.Events.Extensions
         /// </summary>
         public static bool HasRequiredScope(this ClaimsPrincipal user, string requiredScope)
         {
-            string contextScope = user.Identities
-              ?.FirstOrDefault(i => i.AuthenticationType != null && i.AuthenticationType.Equals("AuthenticationTypes.Federation"))?.Claims
-              .Where(c => c.Type.Equals("urn:altinn:scope"))?
-              .Select(c => c.Value).FirstOrDefault();
+            string[] contextScopes = user.Identities
+                ?.FirstOrDefault(i => i.AuthenticationType != null && i.AuthenticationType.Equals("AuthenticationTypes.Federation"))?.Claims
+                .Where(c => c.Type.Equals("urn:altinn:scope"))?
+                .Select(c => c.Value).FirstOrDefault()?.Split(' ');
 
-            contextScope ??= user.Claims.Where(c => c.Type.Equals("scope")).Select(c => c.Value).FirstOrDefault();
+            contextScopes ??= user.Claims.Where(c => c.Type.Equals("scope")).Select(c => c.Value).FirstOrDefault()?.Split(' ');
 
-            if (!string.IsNullOrWhiteSpace(contextScope) && contextScope.Contains(requiredScope, StringComparison.InvariantCultureIgnoreCase))
+            if (contextScopes is not null && contextScopes.Any(x => x.Equals(requiredScope, StringComparison.InvariantCultureIgnoreCase)))
             {
                 return true;
             }

--- a/src/Events/Services/AuthorizationService.cs
+++ b/src/Events/Services/AuthorizationService.cs
@@ -9,9 +9,10 @@ using Altinn.Common.PEP.Constants;
 using Altinn.Common.PEP.Helpers;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Events.Authorization;
+using Altinn.Platform.Events.Configuration;
 using Altinn.Platform.Events.Models;
 using Altinn.Platform.Events.Services.Interfaces;
-
+using Altinn.Platorm.Events.Extensions;
 using CloudNative.CloudEvents;
 
 namespace Altinn.Platform.Events.Services
@@ -60,6 +61,11 @@ namespace Altinn.Platform.Events.Services
         public async Task<bool> AuthorizePublishEvent(CloudEvent cloudEvent)
         {
             ClaimsPrincipal consumer = _claimsPrincipalProvider.GetUser();
+
+            if (consumer.HasRequiredScope(AuthorizationConstants.SCOPE_EVENTS_ADMIN_PUBLISH))
+            {
+                return true;
+            }
 
             XacmlJsonRequestRoot xacmlJsonRequest = GenericCloudEventXacmlMapper.CreateDecisionRequest(consumer, "publish", cloudEvent);
             XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);

--- a/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
@@ -185,6 +186,44 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
             // Act            
             var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object);
+
+            bool actual = await sut.AuthorizePublishEvent(_cloudEvent);
+
+            // Assert
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public async Task AuthorizePublishEventWithAdminScope_IndeterminateResponse_ReturnsTrue()
+        {
+            // Arrange
+            Mock<IPDP> pdpMock = GetPDPMockWithRespose("Indeterminate");
+            Mock<IClaimsPrincipalProvider> principalMock = new();
+            principalMock
+                .Setup(p => p.GetUser())
+                .Returns(PrincipalUtil.GetClaimsPrincipal("digdir", "912345678","altinn:events.publish.admin", "AuthenticationTypes.Federation"));
+
+            // Act
+            var sut = new AuthorizationService(pdpMock.Object, principalMock.Object);
+
+            bool actual = await sut.AuthorizePublishEvent(_cloudEvent);
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public async Task AuthorizePublishEventWithFakedAdminScope_IndeterminateResponse_ReturnsFalse()
+        {
+            // Arrange
+            Mock<IPDP> pdpMock = GetPDPMockWithRespose("Indeterminate");
+            Mock<IClaimsPrincipalProvider> principalMock = new();
+            principalMock
+                .Setup(p => p.GetUser())
+                .Returns(PrincipalUtil.GetClaimsPrincipal("digdir", "912345678","somerandomprefix:altinn:events.publish.admin", "AuthenticationTypes.Federation"));
+
+            // Act
+            var sut = new AuthorizationService(pdpMock.Object, principalMock.Object);
 
             bool actual = await sut.AuthorizePublishEvent(_cloudEvent);
 

--- a/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
@@ -201,7 +201,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             Mock<IClaimsPrincipalProvider> principalMock = new();
             principalMock
                 .Setup(p => p.GetUser())
-                .Returns(PrincipalUtil.GetClaimsPrincipal("digdir", "912345678","altinn:events.publish.admin", "AuthenticationTypes.Federation"));
+                .Returns(PrincipalUtil.GetClaimsPrincipal("digdir", "912345678", "altinn:events.publish.admin", "AuthenticationTypes.Federation"));
 
             // Act
             var sut = new AuthorizationService(pdpMock.Object, principalMock.Object);
@@ -220,7 +220,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             Mock<IClaimsPrincipalProvider> principalMock = new();
             principalMock
                 .Setup(p => p.GetUser())
-                .Returns(PrincipalUtil.GetClaimsPrincipal("digdir", "912345678","somerandomprefix:altinn:events.publish.admin", "AuthenticationTypes.Federation"));
+                .Returns(PrincipalUtil.GetClaimsPrincipal("digdir", "912345678", "somerandomprefix:altinn:events.publish.admin", "AuthenticationTypes.Federation"));
 
             // Act
             var sut = new AuthorizationService(pdpMock.Object, principalMock.Object);

--- a/test/Altinn.Platform.Events.Tests/TestingServices/OutboundServiceTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/OutboundServiceTests.cs
@@ -267,7 +267,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
                    It.IsAny<EventId>(),
                    It.Is<It.IsAnyType>((o, t) => o.ToString().StartsWith("// OutboundService // EnqueueOutbound // Failed to send event envelope", StringComparison.InvariantCultureIgnoreCase)),
                    It.IsAny<Exception>(),
-                   It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                   It.IsAny<Func<It.IsAnyType, Exception, string>>()),
                Times.Once);
             queueMock.VerifyAll();
         }

--- a/test/Altinn.Platform.Events.Tests/Utils/PrincipalUtil.cs
+++ b/test/Altinn.Platform.Events.Tests/Utils/PrincipalUtil.cs
@@ -14,7 +14,7 @@ namespace Altinn.Platform.Events.Tests.Utils
         public static readonly string AltinnCoreClaimTypesOrg = "urn:altinn:org";
         public static readonly string AltinnCoreClaimTypesOrgNumber = "urn:altinn:orgNumber";
 
-        public static ClaimsPrincipal GetClaimsPrincipal(string org, string orgNumber, string scope = null)
+        public static ClaimsPrincipal GetClaimsPrincipal(string org, string orgNumber, string scope = null, string authenticationMethod = null)
         {
             string issuer = "www.altinn.no";
 
@@ -30,10 +30,10 @@ namespace Altinn.Platform.Events.Tests.Utils
             }
 
             claims.Add(new Claim(AltinnCoreClaimTypesOrgNumber, orgNumber.ToString(), ClaimValueTypes.Integer32, issuer));
-            claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticateMethod, "Mock", ClaimValueTypes.String, issuer));
+            claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticateMethod, authenticationMethod ?? "Mock", ClaimValueTypes.String, issuer));
             claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "3", ClaimValueTypes.Integer32, issuer));
 
-            ClaimsIdentity identity = new ClaimsIdentity("mock-org");
+            ClaimsIdentity identity = new ClaimsIdentity(authenticationMethod ?? "mock-org");
             identity.AddClaims(claims);
 
             return new ClaimsPrincipal(identity);


### PR DESCRIPTION
This adds a way to authorize publishing of all event types if a special scope is provided in addition to the ordinary authorization policy.

## Description
This adds a short circuit in the AuthorizationService, checking if the authenticated and authorized principal has supplied a scope-claim containing the `altinn:events.publish.admin`, which will the cause the HTTP request to PEP to be omitted. This will be used by Dialogporten when producing events on behalf of service owners on with arbitrary `resource`-properties. This avoids having to add a rule in all XACMLs for "publish" to Digdir, and avoids the external HTTP requests against Authorization which should help performance.

This also fixes `HasRequiredScope(this ClaimsPrincipal user, string requiredScope)` so that it splits on space and uses `Equals` instead of `Contains` to avoid incorrectly matching on `unrelatedprefix:altinn:events...`

## Related Issue(s)
- https://github.com/digdir/dialogporten/issues/52

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
