### PR TITLE
Initial poc for resource attribute matching of cloud event subjects

### DIFF
--- a/test/Altinn.Platform.Events.Tests/TestingUtils/GenericCloudEventXacmlMapperTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingUtils/GenericCloudEventXacmlMapperTests.cs
@@ -18,6 +18,8 @@ namespace Altinn.Platform.Events.Tests.TestingUtils
     {
         private readonly CloudEvent _cloudEvent;
         private readonly CloudEvent _cloudEventWithResourceInstance;
+        private readonly CloudEvent _cloudEventWithOrgSubject;
+        private readonly CloudEvent _cloudEventWithPartySubject;
 
         public GenericCloudEventXacmlMapperTests()
         {
@@ -30,6 +32,12 @@ namespace Altinn.Platform.Events.Tests.TestingUtils
             };
 
             _cloudEvent["resource"] = "urn:altinn:resource:nbib.bokoversikt.api";
+
+            _cloudEventWithOrgSubject = _cloudEvent.Clone();
+            _cloudEventWithOrgSubject.Subject = "/org/912345678";
+
+            _cloudEventWithPartySubject = _cloudEvent.Clone();
+            _cloudEventWithPartySubject.Subject = "/party/5123456";
 
             _cloudEventWithResourceInstance = new CloudEvent(CloudEventsSpecVersion.V1_0)
             {
@@ -116,7 +124,7 @@ namespace Altinn.Platform.Events.Tests.TestingUtils
         [Fact]
         public void CreateResourceCategory_CloudEventWithoutResourceInstance()
         {
-            int expectedAttributeCount = 4;
+            int expectedAttributeCount = 5;
 
             // Act
             var actual = GenericCloudEventXacmlMapper.CreateResourceCategory(_cloudEvent);
@@ -128,6 +136,7 @@ namespace Altinn.Platform.Events.Tests.TestingUtils
             Assert.Contains(actual.Attribute, a => a.AttributeId.Equals("urn:altinn:eventtype"));
             Assert.Contains(actual.Attribute, a => a.AttributeId.Equals("urn:altinn:eventsource"));
             Assert.Contains(actual.Attribute, a => a.AttributeId.Equals("urn:altinn:resource"));
+            Assert.Contains(actual.Attribute, a => a.AttributeId.Equals("urn:altinn:ssn"));
             Assert.True(actualEventIdAttribute.IncludeInResult);
         }
 
@@ -135,7 +144,7 @@ namespace Altinn.Platform.Events.Tests.TestingUtils
         public void CreateResourceCategory_CloudEventWithResourceInstance()
         {
             // Arrange
-            int expectedAttributeCount = 5;
+            int expectedAttributeCount = 6;
             string expectedResourceId = "resourceInstanceId";
 
             // Act
@@ -145,6 +154,48 @@ namespace Altinn.Platform.Events.Tests.TestingUtils
             // Assert
             Assert.Equal(expectedAttributeCount, actual.Attribute.Count);
             Assert.Equal(expectedResourceId, actualResourceInstancedAttribute.Value);
+        }
+
+        [Fact]
+        public void CreateResourceCategory_CloudEventWithPersonSubject()
+        {
+            // Arrange
+            int expectedAttributeCount = 5;
+
+            // Act
+            var actual = GenericCloudEventXacmlMapper.CreateResourceCategory(_cloudEvent);
+
+            // Assert
+            Assert.Equal(expectedAttributeCount, actual.Attribute.Count);
+            Assert.Contains(actual.Attribute, a => a.AttributeId.Equals("urn:altinn:ssn"));
+        }
+
+        [Fact]
+        public void CreateResourceCategory_CloudEventWithPartySubject()
+        {
+            // Arrange
+            int expectedAttributeCount = 5;
+
+            // Act
+            var actual = GenericCloudEventXacmlMapper.CreateResourceCategory(_cloudEventWithPartySubject);
+
+            // Assert
+            Assert.Equal(expectedAttributeCount, actual.Attribute.Count);
+            Assert.Contains(actual.Attribute, a => a.AttributeId.Equals("urn:altinn:partyid"));
+        }
+
+        [Fact]
+        public void CreateResourceCategory_CloudEventWithOrgSubject()
+        {
+            // Arrange
+            int expectedAttributeCount = 5;
+
+            // Act
+            var actual = GenericCloudEventXacmlMapper.CreateResourceCategory(_cloudEventWithOrgSubject);
+
+            // Assert
+            Assert.Equal(expectedAttributeCount, actual.Attribute.Count);
+            Assert.Contains(actual.Attribute, a => a.AttributeId.Equals("urn:altinn:organizationnumber"));
         }
 
         [Fact]

--- a/test/Altinn.Platform.Events.Tests/Utils/TestdataUtil.cs
+++ b/test/Altinn.Platform.Events.Tests/Utils/TestdataUtil.cs
@@ -44,6 +44,32 @@ namespace Altinn.Platform.Events.Tests.Utils
             return null;
         }
 
+        public static CloudEvent Clone(this CloudEvent cloudEvent)
+        {
+            CloudEvent copy = new CloudEvent(cloudEvent.SpecVersion)
+            {
+                Id = cloudEvent.Id,
+                Data = cloudEvent.Data,
+                DataContentType = cloudEvent.DataContentType,
+                DataSchema = cloudEvent.DataSchema,
+                Source = cloudEvent.Source,
+                Subject = cloudEvent.Subject,
+                Time = cloudEvent.Time,
+                Type = cloudEvent.Type
+            };
+            if (cloudEvent["resource"] is not null)
+            {
+                copy["resource"] = cloudEvent["resource"];
+            }
+
+            if (cloudEvent["resourceinstance"] is not null)
+            {
+                copy["resourceinstance"] = cloudEvent["resourceinstance"];
+            }
+
+            return copy;
+        }
+
         private static string GetXacmlResponsePath()
         {
             string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(TestdataUtil).Assembly.Location).LocalPath);


### PR DESCRIPTION
This implements a approach to support role/accessgroup-based authorization of service resources refered to by generic cloud events.

## Description
This simply extends `CreateResourceCategory` used by `GenericCloudEventMapper.CreateDecisionRequest` to parse the subject-property of the given cloudevent, and - if it matches a known prefix - maps these attributes to the resource category. This will allow the PDP to enrich the subject with roles/access groups, and apply to POST and (current) GET actions for the events-API, outbound pushed events and presumably subscription requests (once implemented)

### Considerations
* There are no attempts made to ensure that the XACML subject attributes contains something that the PDP is able to use in order to get roles/access groups. With Altinn-tokens, the userId claim is present and will be copied into the authorization request. 
* The event component does not attempt to resolve the subject to partyId, this should be the PDPs job to do  (and cache) - and can determine to not do so if the relevant policy does not require it
* The PDP currently supports only [partyId and organization numbers](https://github.com/Altinn/altinn-authorization/blob/main/src/Authorization/Services/Implementation/ContextHandler.cs#L167), not SSNs, but this can be easily extended.
* The GET endpoint can at some point be optimized to perform an authorization request based on the supplied service resource first, and use obligations from the PEP to filter subjects/types in the database query. 

