### PR TITLE
Allow apps to indicate event should be handled as generic

### DIFF
--- a/src/Events/Services/OutboundService.cs
+++ b/src/Events/Services/OutboundService.cs
@@ -179,7 +179,12 @@ namespace Altinn.Platform.Events.Services
 
         private bool IsAppEvent(CloudEvent cloudEvent)
         {
-            return !string.IsNullOrEmpty(cloudEvent.Source.Host) && cloudEvent.Source.Host.EndsWith(_platformSettings.AppsDomain);
+            return cloudEvent.Source != null
+                   && !string.IsNullOrEmpty(cloudEvent.Source.Host) 
+                   && cloudEvent.Source.Host.EndsWith(_platformSettings.AppsDomain) 
+                   &&
+                   (string.IsNullOrEmpty(cloudEvent.Source?.Query) ||
+                    cloudEvent.Source.Query.ToLowerInvariant().Contains("isgenericevent=true") != true);
         }
     }
 }


### PR DESCRIPTION
By extending the IsAppEvent check to also look for this custom and temporary flag, early adopters can test generic handling of app events at a very granular level (per event).

## Related Issue(s)
- #377 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
