### PR TITLE
null handling for sourcefilter in validation

### DIFF
--- a/src/Events/Services/AppSubscriptionService.cs
+++ b/src/Events/Services/AppSubscriptionService.cs
@@ -122,7 +122,7 @@ namespace Altinn.Platform.Events.Services
             }
 
             if (!string.IsNullOrEmpty(eventsSubscription.ResourceFilter) &&
-                !string.IsNullOrEmpty(eventsSubscription.SourceFilter.ToString()) &&
+                !string.IsNullOrEmpty(eventsSubscription.SourceFilter?.ToString()) &&
                 !GetResourceFilterFromSource(eventsSubscription.SourceFilter).Equals(eventsSubscription.ResourceFilter))
             {
                 message = "Provided resource filter and source filter are not compatible";

--- a/test/Altinn.Platform.Events.Tests/TestingServices/AppSubscriptionServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/AppSubscriptionServiceTest.cs
@@ -103,6 +103,37 @@ namespace Altinn.Platform.Events.Tests.TestingServices
         }
 
         [Fact]
+        public async Task CreateSubscription_NoSourceFilter_SubscriptionCreated()
+        {
+            // Arrange
+            string expectedSubjectFilter = "/party/1337";
+            int subscriptionId = 1337;
+
+            var subs = new Subscription
+            {
+                Id = subscriptionId,
+                AlternativeSubjectFilter = "/person/01039012345",
+                ResourceFilter = "urn:altinn:resource:altinnapp.ttd.apps-test"
+            };
+
+            Mock<IRegisterService> registerMock = new();
+            registerMock
+                .Setup(r => r.PartyLookup(It.IsAny<string>(), It.Is<string>(s => s.Equals("01039012345"))))
+                .ReturnsAsync(1337);
+
+            var sut = GetAppSubscriptionService(
+                register: registerMock.Object,
+                authorization: _authTrueMock.Object);
+
+            // Act
+            (Subscription actual, ServiceError _) = await sut.CreateSubscription(subs);
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.Equal(expectedSubjectFilter, actual.SubjectFilter);
+        }
+
+        [Fact]
         public async Task CreateSubscription_NonExistentAlternativeSubject_ReturnsError()
         {
             // Arrange


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Null value handling in app subscription servce. Not assuming that sourcefilter isn't null
## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
