### PR TITLE
Revert bumping of AspNetCore.HealthChecks.NpgSql

### DIFF
--- a/src/Events/Altinn.Platform.Events.csproj
+++ b/src/Events/Altinn.Platform.Events.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Altinn.Common.PEP" Version="1.3.0" />
     <PackageReference Include="Altinn.Common.AccessToken" Version="3.0.1" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.2.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="7.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.23.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageReference Include="Azure.Identity" Version="1.10.0" />


### PR DESCRIPTION
## Description
Bumping the AspNetCore.HealthChecks.NpgSql is now the probable cause of crash loop in events. Revering the bump.

## Related Issue(s)
- Patching

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
