### PR TITLE
Testing the latest preview version of the AccessToken libraries.

### DIFF
--- a/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
+++ b/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Upgrading to 1.1.4 will cause the function to fail, must upgrade function to .net 7 first-->
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.3" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="2.0.0-preview" />
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.5.1" />

--- a/src/Events/Altinn.Platform.Events.csproj
+++ b/src/Events/Altinn.Platform.Events.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Authorization.ABAC" Version="0.0.7" />
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.5" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="2.0.0-preview" />
     <PackageReference Include="Altinn.Common.PEP" Version="1.3.0" />
-    <PackageReference Include="Altinn.Common.AccessToken" Version="3.0.3" />
+    <PackageReference Include="Altinn.Common.AccessToken" Version="4.0.0-preview" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.2.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="7.1.0" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.24.0" />


### PR DESCRIPTION
## Description
This change is upgrading the AccessToken libraries to the latest preview. This is primarily to test the packages in dotnet 7 and dotnet 6 projects.

## Related Issue(s)
- https://github.com/Altinn/altinn-accesstoken/issues/74

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

