### PR TITLE
Persist request body in telemetry if request results in error response 

### DIFF
--- a/src/Events/Controllers/SubscriptionController.cs
+++ b/src/Events/Controllers/SubscriptionController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Events.Configuration;
@@ -10,6 +11,7 @@ using Altinn.Platorm.Events.Extensions;
 
 using AutoMapper;
 
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -93,6 +95,7 @@ namespace Altinn.Platform.Events.Controllers
 
             if (error != null)
             {
+                AddQueryModelToTelemetry(subscriptionRequest);
                 return StatusCode(error.ErrorCode, error.ErrorMessage);
             }
 
@@ -201,6 +204,18 @@ namespace Altinn.Platform.Events.Controllers
             }
 
             return false;
+        }
+
+        private void AddQueryModelToTelemetry(SubscriptionRequestModel subscriptionRequest)
+        {
+            RequestTelemetry requestTelemetry = HttpContext.Features.Get<RequestTelemetry>();
+
+            if (requestTelemetry == null)
+            {
+                return;
+            }
+
+            requestTelemetry.Properties.Add("subscription.request", JsonSerializer.Serialize(subscriptionRequest));
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
IN some cases subscription controller can respond with 500. To make debugging these cases easier we persist the subscription request with all input parameters in these cases. 

## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
