### PR TITLE
Avoid referencing pg_cron when running locally

### DIFF
--- a/src/Events/Migration/v0.19/01-setup-cron-job.sql
+++ b/src/Events/Migration/v0.19/01-setup-cron-job.sql
@@ -1,1 +1,8 @@
-SELECT cron.schedule('0 3 * * *', $$DELETE FROM events.events_app WHERE time < now() - interval '90 days'$$);
+DO
+$do$
+BEGIN
+	IF EXISTS (SELECT setting FROM pg_settings WHERE name = 'azure.customer_resource_group') THEN
+		SELECT cron.schedule('0 3 * * *', $$DELETE FROM events.events_app WHERE time < now() - interval '90 days'$$);
+	END IF;
+END
+$do$

--- a/src/Events/Migration/v0.21/03-setup-cron-job.sql
+++ b/src/Events/Migration/v0.21/03-setup-cron-job.sql
@@ -1,1 +1,8 @@
-SELECT cron.schedule('0 3 * * *', $$DELETE FROM events.events WHERE registeredtime < now() - interval '90 days'$$);
+DO
+$do$
+BEGIN
+	IF EXISTS (SELECT setting FROM pg_settings WHERE name = 'azure.customer_resource_group') THEN
+		SELECT cron.schedule('0 3 * * *', $$DELETE FROM events.events WHERE registeredtime < now() - interval '90 days'$$);
+	END IF;
+END
+$do$


### PR DESCRIPTION
## Description
Avoid referencing pg_cron when running locally

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
