### PR TITLE
#528 Reverting the AccessTokenClient to 1.1.3

### DIFF
--- a/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
+++ b/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Upgrading to 1.1.4 will cause the function to fail, must upgrade function to .net 7 first-->
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.5" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.3" />
     <PackageReference Include="Azure.Identity" Version="1.11.2" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />


### PR DESCRIPTION
Reverting the AccessTokenClient to 1.1.3

## Description
Reverting the AccessTokenClient to 1.1.3

## Related Issue(s)
- #528 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] All tests run green
