### PR TITLE
subject attributes included in resource for decision request

### DIFF
--- a/src/Events/Authorization/AppCloudEventXacmlMapper.cs
+++ b/src/Events/Authorization/AppCloudEventXacmlMapper.cs
@@ -44,7 +44,7 @@ namespace Altinn.Platform.Events.Authorization
 
             (string org, string app, string instanceOwnerPartyId, string instanceGuid) = AppCloudEventExtensions.GetPropertiesFromAppSource(cloudEvent.Source);
 
-            request.AccessSubject.Add(XacmlMapperHelper.CreateSubjectAttributes(subject));
+            request.AccessSubject.Add(new XacmlJsonCategory().AddSubjectAttributes(subject));
             request.Action.Add(CloudEventXacmlMapper.CreateActionCategory("read"));
             request.Resource.Add(CreateEventsResourceCategory(org, app, instanceOwnerPartyId, instanceGuid));
 

--- a/src/Events/Authorization/AppCloudEventXacmlMapper.cs
+++ b/src/Events/Authorization/AppCloudEventXacmlMapper.cs
@@ -44,7 +44,7 @@ namespace Altinn.Platform.Events.Authorization
 
             (string org, string app, string instanceOwnerPartyId, string instanceGuid) = AppCloudEventExtensions.GetPropertiesFromAppSource(cloudEvent.Source);
 
-            request.AccessSubject.Add(new XacmlJsonCategory().AddSubjectAttributes(subject));
+            request.AccessSubject.Add(new XacmlJsonCategory().AddSubjectAttribute(subject));
             request.Action.Add(CloudEventXacmlMapper.CreateActionCategory("read"));
             request.Resource.Add(CreateEventsResourceCategory(org, app, instanceOwnerPartyId, instanceGuid));
 

--- a/src/Events/Authorization/GenericCloudEventXacmlMapper.cs
+++ b/src/Events/Authorization/GenericCloudEventXacmlMapper.cs
@@ -47,7 +47,7 @@ namespace Altinn.Platform.Events.Authorization
         /// <param name="cloudEvent">The cloud events to publish</param>
         public static XacmlJsonRequestRoot CreateDecisionRequest(string consumer, string actionType, CloudEvent cloudEvent)
         {
-            return CreateDecisionRequest(XacmlMapperHelper.CreateSubjectAttributes(consumer), actionType, cloudEvent);
+            return CreateDecisionRequest(new XacmlJsonCategory().AddSubjectAttributes(consumer), actionType, cloudEvent);
         }
 
         private static XacmlJsonRequestRoot CreateDecisionRequest(XacmlJsonCategory subjectAttributes, string actionType, CloudEvent cloudEvent)
@@ -104,8 +104,8 @@ namespace Altinn.Platform.Events.Authorization
             resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.EventId, cloudEvent.Id, defaultType, defaultIssuer, true));
             resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.EventType, cloudEvent.Type, defaultType, defaultIssuer));
             resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.EventSource, cloudEvent.Source.ToString(), defaultType, defaultIssuer));
-            resourceCategory.SetXacmlJsonAttributeFromUrn(cloudEvent.GetResource());
-            resourceCategory.SetXacmlJsonAttributeFromUrn(cloudEvent.Subject); // only urn formated subjects included in authorization request
+            resourceCategory.AddXacmlJsonAttributeFromUrn(cloudEvent.GetResource());
+            resourceCategory.AddXacmlJsonAttributeFromUrn(cloudEvent.Subject); // only urn formated subjects included in authorization request
 
             if (cloudEvent["resourceinstance"] is not null)
             {

--- a/src/Events/Authorization/GenericCloudEventXacmlMapper.cs
+++ b/src/Events/Authorization/GenericCloudEventXacmlMapper.cs
@@ -104,16 +104,13 @@ namespace Altinn.Platform.Events.Authorization
             resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.EventId, cloudEvent.Id, defaultType, defaultIssuer, true));
             resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.EventType, cloudEvent.Type, defaultType, defaultIssuer));
             resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.EventSource, cloudEvent.Source.ToString(), defaultType, defaultIssuer));
-            (string resourceId, string resourceValue) = XacmlMapperHelper.SplitResourceInTwoParts(cloudEvent.GetResource());
-
-            resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(resourceId, resourceValue, defaultType, defaultIssuer));
+            resourceCategory.SetXacmlJsonAttributeFromUrn(cloudEvent.GetResource());
+            resourceCategory.SetXacmlJsonAttributeFromUrn(cloudEvent.Subject); // only urn formated subjects included in authorization request
 
             if (cloudEvent["resourceinstance"] is not null)
             {
                 resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.ResourceInstance, cloudEvent["resourceinstance"].ToString(), defaultType, defaultIssuer));
             }
-
-            XacmlMapperHelper.AddResourcePartyAttributeFromCloudEventSubject(cloudEvent, resourceCategory);
 
             return resourceCategory;
         }

--- a/src/Events/Authorization/GenericCloudEventXacmlMapper.cs
+++ b/src/Events/Authorization/GenericCloudEventXacmlMapper.cs
@@ -47,7 +47,7 @@ namespace Altinn.Platform.Events.Authorization
         /// <param name="cloudEvent">The cloud events to publish</param>
         public static XacmlJsonRequestRoot CreateDecisionRequest(string consumer, string actionType, CloudEvent cloudEvent)
         {
-            return CreateDecisionRequest(new XacmlJsonCategory().AddSubjectAttributes(consumer), actionType, cloudEvent);
+            return CreateDecisionRequest(new XacmlJsonCategory().AddSubjectAttribute(consumer), actionType, cloudEvent);
         }
 
         private static XacmlJsonRequestRoot CreateDecisionRequest(XacmlJsonCategory subjectAttributes, string actionType, CloudEvent cloudEvent)
@@ -104,8 +104,8 @@ namespace Altinn.Platform.Events.Authorization
             resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.EventId, cloudEvent.Id, defaultType, defaultIssuer, true));
             resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.EventType, cloudEvent.Type, defaultType, defaultIssuer));
             resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.EventSource, cloudEvent.Source.ToString(), defaultType, defaultIssuer));
-            resourceCategory.AddXacmlJsonAttributeFromUrn(cloudEvent.GetResource());
-            resourceCategory.AddXacmlJsonAttributeFromUrn(cloudEvent.Subject); // only urn formated subjects included in authorization request
+            resourceCategory.AddAttributeFromUrn(cloudEvent.GetResource());
+            resourceCategory.AddAttributeFromUrn(cloudEvent.Subject); // only urn formated subjects included in authorization request
 
             if (cloudEvent["resourceinstance"] is not null)
             {

--- a/src/Events/Authorization/SubscriptionXacmlMapper.cs
+++ b/src/Events/Authorization/SubscriptionXacmlMapper.cs
@@ -61,9 +61,7 @@ namespace Altinn.Platform.Events.Authorization
                 Attribute = new List<XacmlJsonAttribute>()
             };
 
-            (string resourceFilterId, string resourceFilterValue) = XacmlMapperHelper.SplitResourceInTwoParts(subscription.ResourceFilter);
-
-            resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(resourceFilterId, resourceFilterValue, DefaultType, DefaultIssuer));
+            resourceCategory.SetXacmlJsonAttributeFromUrn(subscription.ResourceFilter);
 
             if (!string.IsNullOrEmpty(subscription.SubjectFilter))
             {
@@ -73,6 +71,8 @@ namespace Altinn.Platform.Events.Authorization
 
             if (isAppEventSubs)
             {
+                (_, string resourceFilterValue) = XacmlMapperHelper.SplitResourceInTwoParts(subscription.ResourceFilter);
+
                 string[] resourceAttParts = resourceFilterValue.Split('_');
                 string org = resourceAttParts[1];
                 string app = resourceAttParts[2];

--- a/src/Events/Authorization/SubscriptionXacmlMapper.cs
+++ b/src/Events/Authorization/SubscriptionXacmlMapper.cs
@@ -33,7 +33,7 @@ namespace Altinn.Platform.Events.Authorization
                 Resource = new List<XacmlJsonCategory>()
             };
 
-            request.AccessSubject.Add(new XacmlJsonCategory().AddSubjectAttributes(subscription.Consumer));
+            request.AccessSubject.Add(new XacmlJsonCategory().AddSubjectAttribute(subscription.Consumer));
             request.Action.Add(CreateActionCategory(action));
             request.Resource.Add(CreateResourceCategory(subscription, isAppSubs));
 
@@ -61,8 +61,8 @@ namespace Altinn.Platform.Events.Authorization
                 Attribute = new List<XacmlJsonAttribute>()
             };
 
-            resourceCategory.AddXacmlJsonAttributeFromUrn(subscription.ResourceFilter);
-            resourceCategory.AddSubjectAttributes(subscription.SubjectFilter);
+            resourceCategory.AddAttributeFromUrn(subscription.ResourceFilter);
+            resourceCategory.AddSubjectAttribute(subscription.SubjectFilter);
 
             if (isAppEventSubs)
             {

--- a/src/Events/Authorization/SubscriptionXacmlMapper.cs
+++ b/src/Events/Authorization/SubscriptionXacmlMapper.cs
@@ -33,7 +33,7 @@ namespace Altinn.Platform.Events.Authorization
                 Resource = new List<XacmlJsonCategory>()
             };
 
-            request.AccessSubject.Add(XacmlMapperHelper.CreateSubjectAttributes(subscription.Consumer));
+            request.AccessSubject.Add(new XacmlJsonCategory().AddSubjectAttributes(subscription.Consumer));
             request.Action.Add(CreateActionCategory(action));
             request.Resource.Add(CreateResourceCategory(subscription, isAppSubs));
 
@@ -61,13 +61,8 @@ namespace Altinn.Platform.Events.Authorization
                 Attribute = new List<XacmlJsonAttribute>()
             };
 
-            resourceCategory.SetXacmlJsonAttributeFromUrn(subscription.ResourceFilter);
-
-            if (!string.IsNullOrEmpty(subscription.SubjectFilter))
-            {
-                XacmlJsonCategory subjectAttributes = XacmlMapperHelper.CreateSubjectAttributes(subscription.SubjectFilter);
-                resourceCategory.Attribute.AddRange(subjectAttributes.Attribute);
-            }
+            resourceCategory.AddXacmlJsonAttributeFromUrn(subscription.ResourceFilter);
+            resourceCategory.AddSubjectAttributes(subscription.SubjectFilter);
 
             if (isAppEventSubs)
             {

--- a/src/Events/Authorization/XacmlMapperHelper.cs
+++ b/src/Events/Authorization/XacmlMapperHelper.cs
@@ -1,9 +1,10 @@
 #nullable enable
 
 using System.Security.Claims;
+
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
 using Altinn.Common.PEP.Helpers;
-using CloudNative.CloudEvents;
+using Altinn.Platform.Events.Extensions;
 
 namespace Altinn.Platform.Events.Authorization;
 
@@ -24,7 +25,6 @@ public static class XacmlMapperHelper
     private const string ClaimPartyID = "urn:altinn:partyid";
 
     private const string ClaimOrganizationNumber = "urn:altinn:organization:identifier-no";
-    private const string ClaimPersonNumber = "urn:altinn:person:identifier-no";
     private const string ClaimIdentitySeparator = ":";
 
     /// <summary>
@@ -58,8 +58,42 @@ public static class XacmlMapperHelper
             string value = subject.Replace(OrganisationPrefix, string.Empty);
             category.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimOrganizationNumber, value, ClaimValueTypes.String, DefaultIssuer));
         }
+        else if (UriExtensions.IsValidUrn(subject))
+        {
+            category.SetXacmlJsonAttributeFromUrn(subject);
+        }
 
         return category;
+    }
+
+    /// <summary>
+    /// Maps a urn string to a XACML resource attribute in the provided xacml category instance.
+    /// </summary>
+    /// <remarks>
+    /// URN is split at the last colon (`:`) of the string an first part is used as the
+    /// attribute type and last part is used as the value.
+    /// Given an invalid URN or empty string the category is left unmodified.
+    /// </remarks>
+    /// <param name="jsonCategory">The XACML category to be populated</param>
+    /// <param name="urn">The urn to retrieve attribute type and value from</param>
+    public static void SetXacmlJsonAttributeFromUrn(this XacmlJsonCategory jsonCategory, string urn)
+    {
+        if (string.IsNullOrEmpty(urn))
+        {
+            return;
+        }
+
+        string[] typeAndValue = urn.Split(ClaimIdentitySeparator);
+
+        if (typeAndValue.Length < 2)
+        {
+            return;
+        }
+
+        var value = typeAndValue[^1];
+        var type = string.Join(ClaimIdentitySeparator, typeAndValue[..^1]);
+
+        jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(type, value, CloudEventXacmlMapper.DefaultType, CloudEventXacmlMapper.DefaultIssuer));
     }
 
     /// <summary>
@@ -74,47 +108,10 @@ public static class XacmlMapperHelper
     /// </remarks>
     public static (string AttributeId, string AttributeValue) SplitResourceInTwoParts(string resource)
     {
-        int index = resource.LastIndexOf(':');
+        int index = resource.LastIndexOf(ClaimIdentitySeparator);
         string id = resource.Substring(0, index);
         string value = resource.Substring(index + 1);
 
         return (id, value);
-    }
-
-    /// <summary>
-    /// Maps a subject in the provided CloudEvent to a XACML resource attribute in the provided resource category instance.
-    /// </summary>
-    /// <remarks>
-    /// A recognized subject property value begins with one of the prefixes "urn:altinn:organization:identifier-no",
-    /// or "urn:altinn:person:identifier-no", which is copied to the resource attribute with the corresponding URN.
-    /// This will enable the PDP to enrich the request with roles etc. that the user has in the context of the CloudEvent
-    /// subject (aka reportee).
-    ///
-    /// Also note that this requires a XACML subject attribute that the PDP understands in order to look up the user's
-    /// roles/access groups for that particular party, eg. "urn:altinn:userid" or "urn:altinn:person:identifier-no".
-    /// </remarks>
-    /// <param name="cloudEvent">CloudEvent containing a subject representing a party</param>
-    /// <param name="resourceCategory">The XACML resource category to be populated</param>
-    public static void AddResourcePartyAttributeFromCloudEventSubject(CloudEvent cloudEvent, XacmlJsonCategory resourceCategory)
-    {
-        if (string.IsNullOrEmpty(cloudEvent.Subject))
-        {
-            return;
-        }
-
-        string[] typeAndValue = cloudEvent.Subject.Split(ClaimIdentitySeparator);
-        if (typeAndValue.Length < 2)
-        {
-            return;
-        }
-
-        var value = typeAndValue[^1];
-        var type = string.Join(ClaimIdentitySeparator, typeAndValue[..^1]);
-        if (type != ClaimOrganizationNumber && type != ClaimPersonNumber)
-        {
-            return;
-        }
-
-        resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(type, value, CloudEventXacmlMapper.DefaultType, CloudEventXacmlMapper.DefaultIssuer));
     }
 }

--- a/src/Events/Authorization/XacmlMapperHelper.cs
+++ b/src/Events/Authorization/XacmlMapperHelper.cs
@@ -26,44 +26,45 @@ public static class XacmlMapperHelper
 
     private const string ClaimOrganizationNumber = "urn:altinn:organization:identifier-no";
     private const string ClaimIdentitySeparator = ":";
-
+    
     /// <summary>
-    /// Generates subject attribute list
+    /// Adds attributes to the XacmlJsonCateogry from the provided subject string
     /// </summary>
-    /// <returns>The XacmlJsonCategory or the subject</returns>
-    public static XacmlJsonCategory CreateSubjectAttributes(string subject)
+    public static XacmlJsonCategory AddSubjectAttributes(this XacmlJsonCategory jsonCategory, string subject)
     {
-        XacmlJsonCategory category = new()
+        if (string.IsNullOrEmpty(subject))
         {
-            Attribute = []
-        };
+            return jsonCategory;
+        }
+
+        jsonCategory.Attribute ??= [];
 
         if (subject.StartsWith(UserPrefix))
         {
             string value = subject.Replace(UserPrefix, string.Empty);
-            category.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimUserId, value, ClaimValueTypes.String, DefaultIssuer));
+            jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimUserId, value, ClaimValueTypes.String, DefaultIssuer));
         }
         else if (subject.StartsWith(OrgPrefix))
         {
             string value = subject.Replace(OrgPrefix, string.Empty);
-            category.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimOrg, value, ClaimValueTypes.String, DefaultIssuer));
+            jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimOrg, value, ClaimValueTypes.String, DefaultIssuer));
         }
         else if (subject.StartsWith(PartyPrefix))
         {
             string value = subject.Replace(PartyPrefix, string.Empty);
-            category.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimPartyID, value, ClaimValueTypes.Integer, DefaultIssuer));
+            jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimPartyID, value, ClaimValueTypes.Integer, DefaultIssuer));
         }
         else if (subject.StartsWith(OrganisationPrefix))
         {
             string value = subject.Replace(OrganisationPrefix, string.Empty);
-            category.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimOrganizationNumber, value, ClaimValueTypes.String, DefaultIssuer));
+            jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimOrganizationNumber, value, ClaimValueTypes.String, DefaultIssuer));
         }
         else if (UriExtensions.IsValidUrn(subject))
         {
-            category.SetXacmlJsonAttributeFromUrn(subject);
+            jsonCategory.AddXacmlJsonAttributeFromUrn(subject);
         }
 
-        return category;
+        return jsonCategory;
     }
 
     /// <summary>
@@ -86,7 +87,7 @@ public static class XacmlMapperHelper
     }
 
     /// <summary>
-    /// Maps a urn string to a XACML resource attribute in the provided xacml category instance.
+    /// Adds a new json attribute to a provided xacml category instance based of a urn.
     /// </summary>
     /// <remarks>
     /// URN is split at the last colon (`:`) of the string an first part is used as the
@@ -95,7 +96,7 @@ public static class XacmlMapperHelper
     /// </remarks>
     /// <param name="jsonCategory">The XACML category to be populated</param>
     /// <param name="urn">The urn to retrieve attribute type and value from</param>
-    public static void SetXacmlJsonAttributeFromUrn(this XacmlJsonCategory jsonCategory, string urn)
+    public static void AddXacmlJsonAttributeFromUrn(this XacmlJsonCategory jsonCategory, string urn)
     {
         if (string.IsNullOrEmpty(urn))
         {

--- a/src/Events/Authorization/XacmlMapperHelper.cs
+++ b/src/Events/Authorization/XacmlMapperHelper.cs
@@ -30,41 +30,41 @@ public static class XacmlMapperHelper
     /// <summary>
     /// Adds attribute to the XacmlJsonCateogry from the provided subject string
     /// </summary>
-    public static XacmlJsonCategory AddSubjectAttribute(this XacmlJsonCategory jsonCategory, string subject)
+    public static XacmlJsonCategory AddSubjectAttribute(this XacmlJsonCategory xacmlCategory, string subject)
     {
         if (string.IsNullOrEmpty(subject))
         {
-            return jsonCategory;
+            return xacmlCategory;
         }
 
-        jsonCategory.Attribute ??= [];
+        xacmlCategory.Attribute ??= [];
 
         if (subject.StartsWith(UserPrefix))
         {
             string value = subject.Replace(UserPrefix, string.Empty);
-            jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimUserId, value, ClaimValueTypes.String, DefaultIssuer));
+            xacmlCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimUserId, value, ClaimValueTypes.String, DefaultIssuer));
         }
         else if (subject.StartsWith(OrgPrefix))
         {
             string value = subject.Replace(OrgPrefix, string.Empty);
-            jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimOrg, value, ClaimValueTypes.String, DefaultIssuer));
+            xacmlCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimOrg, value, ClaimValueTypes.String, DefaultIssuer));
         }
         else if (subject.StartsWith(PartyPrefix))
         {
             string value = subject.Replace(PartyPrefix, string.Empty);
-            jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimPartyID, value, ClaimValueTypes.Integer, DefaultIssuer));
+            xacmlCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimPartyID, value, ClaimValueTypes.Integer, DefaultIssuer));
         }
         else if (subject.StartsWith(OrganisationPrefix))
         {
             string value = subject.Replace(OrganisationPrefix, string.Empty);
-            jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimOrganizationNumber, value, ClaimValueTypes.String, DefaultIssuer));
+            xacmlCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(ClaimOrganizationNumber, value, ClaimValueTypes.String, DefaultIssuer));
         }
         else if (UriExtensions.IsValidUrn(subject))
         {
-            jsonCategory.AddAttributeFromUrn(subject);
+            xacmlCategory.AddAttributeFromUrn(subject);
         }
 
-        return jsonCategory;
+        return xacmlCategory;
     }
 
     /// <summary>
@@ -75,9 +75,9 @@ public static class XacmlMapperHelper
     /// attribute type and last part is used as the value.
     /// Given an invalid URN or empty string the category is left unmodified.
     /// </remarks>
-    /// <param name="jsonCategory">The XACML category to be populated</param>
+    /// <param name="xacmlCategory">The XACML category to be populated</param>
     /// <param name="urn">The urn to retrieve attribute type and value from</param>
-    public static void AddAttributeFromUrn(this XacmlJsonCategory jsonCategory, string urn)
+    public static void AddAttributeFromUrn(this XacmlJsonCategory xacmlCategory, string urn)
     {
         if (string.IsNullOrEmpty(urn))
         {
@@ -94,7 +94,7 @@ public static class XacmlMapperHelper
         var value = typeAndValue[^1];
         var type = string.Join(ClaimIdentitySeparator, typeAndValue[..^1]);
 
-        jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(type, value, CloudEventXacmlMapper.DefaultType, CloudEventXacmlMapper.DefaultIssuer));
+        xacmlCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(type, value, CloudEventXacmlMapper.DefaultType, CloudEventXacmlMapper.DefaultIssuer));
     }
 
     /// <summary>

--- a/src/Events/Authorization/XacmlMapperHelper.cs
+++ b/src/Events/Authorization/XacmlMapperHelper.cs
@@ -67,6 +67,25 @@ public static class XacmlMapperHelper
     }
 
     /// <summary>
+    /// Splits the resource attribute at the final ':'
+    /// </summary>
+    /// <param name="resource">The resource string</param>
+    /// <returns>A tuple conaining the attribute id and attribute value</returns>
+    /// <remarks>
+    /// First entry should be used as the attribute id in the xacml request
+    /// Second entry should be used as the atttribute value in the xaml request
+    /// For an Altinn App resource second entry is on format altinnapp.{org}.{app}
+    /// </remarks>
+    public static (string AttributeId, string AttributeValue) SplitResourceInTwoParts(string resource)
+    {
+        int index = resource.LastIndexOf(ClaimIdentitySeparator);
+        string id = resource.Substring(0, index);
+        string value = resource.Substring(index + 1);
+
+        return (id, value);
+    }
+
+    /// <summary>
     /// Maps a urn string to a XACML resource attribute in the provided xacml category instance.
     /// </summary>
     /// <remarks>
@@ -94,24 +113,5 @@ public static class XacmlMapperHelper
         var type = string.Join(ClaimIdentitySeparator, typeAndValue[..^1]);
 
         jsonCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(type, value, CloudEventXacmlMapper.DefaultType, CloudEventXacmlMapper.DefaultIssuer));
-    }
-
-    /// <summary>
-    /// Splits the resource attribute at the final ':'
-    /// </summary>
-    /// <param name="resource">The resource string</param>
-    /// <returns>A tuple conaining the attribute id and attribute value</returns>
-    /// <remarks>
-    /// First entry should be used as the attribute id in the xacml request
-    /// Second entry should be used as the atttribute value in the xaml request
-    /// For an Altinn App resource second entry is on format altinnapp.{org}.{app}
-    /// </remarks>
-    public static (string AttributeId, string AttributeValue) SplitResourceInTwoParts(string resource)
-    {
-        int index = resource.LastIndexOf(ClaimIdentitySeparator);
-        string id = resource.Substring(0, index);
-        string value = resource.Substring(index + 1);
-
-        return (id, value);
     }
 }

--- a/test/Altinn.Platform.Events.Tests/TestingUtils/XacmlMapperHelperTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingUtils/XacmlMapperHelperTests.cs
@@ -17,7 +17,7 @@ public class XacmlMapperHelperTests
     public void CreateSubjectAttributes_Assert_correct_attribute_id_and_value(string subject, string attributId, string value)
     {
         // Act
-        XacmlJsonCategory actual = new XacmlJsonCategory().AddSubjectAttributes(subject);
+        XacmlJsonCategory actual = new XacmlJsonCategory().AddSubjectAttribute(subject);
 
         // Assert
         Assert.Single(actual.Attribute);

--- a/test/Altinn.Platform.Events.Tests/TestingUtils/XacmlMapperHelperTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingUtils/XacmlMapperHelperTests.cs
@@ -17,7 +17,7 @@ public class XacmlMapperHelperTests
     public void CreateSubjectAttributes_Assert_correct_attribute_id_and_value(string subject, string attributId, string value)
     {
         // Act
-        XacmlJsonCategory actual = XacmlMapperHelper.CreateSubjectAttributes(subject);
+        XacmlJsonCategory actual = new XacmlJsonCategory().AddSubjectAttributes(subject);
 
         // Assert
         Assert.Single(actual.Attribute);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- For both generic and app events, if a subject filter is included the subject value is included as a part of the resource definition in the decision request. 
- Extension methods for adding attributes to a XacmlJsonCategory one specifically for urns, does not analyze the contents in any way and one specified on subject which supports both urn and known formsats such as /user/1234 and /organisation/23456

## Related Issue(s)
- #520

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
