### PR TITLE
Bump dependencies

### DIFF
--- a/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
+++ b/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
@@ -6,18 +6,18 @@
     <ProjectGuid>{1F3A1E44-1333-46B8-8A70-08BE01C074F6}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Upgrading to 1.1.4 will cause the function to fail, must upgrade function to .net 7 first-->
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.3" />
-    <PackageReference Include="Azure.Identity" Version="1.11.3" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="3.0.3" />
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.7.1" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.7.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.6.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description
It's about time to find out in more detail why it fails when updating AccessTokenClient.