### PR TITLE
Revert Altinn.Common.AccessTokenClient version to 1.1.3

### DIFF
--- a/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
+++ b/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Upgrading to 1.1.5 will cause the function to fail, must upgrade function to .net 7 first-->
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.5" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.3" />
     <PackageReference Include="Azure.Identity" Version="1.13.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
Revert Altinn.Common.AccessTokenClient version to 1.1.3

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
