### PR TITLE
Replace hardcoded webook URL with var in Events.postman_collection.json

### DIFF
--- a/test/Postman/Events.postman_collection.json
+++ b/test/Postman/Events.postman_collection.json
@@ -324,7 +324,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n  \"sourceFilter\": \"https://ttd.apps.at22.altinn.cloud/ttd/apps-test\",\r\n    \"endpoint\": \"https://hooks.slack.com/services/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\"\r\n}",
+					"raw": "{\r\n  \"sourceFilter\": \"https://ttd.apps.at22.altinn.cloud/ttd/apps-test\",\r\n    \"endpoint\": \"{{AltinnSlackWebHook}}\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"


### PR DESCRIPTION
I believe I have verified that the webhook is no longer valid. 
In Postman, I performed a POST to the webhook URL with a simple {"text" : ".."} json payload. The result was 403 Forbidden, "invalid_token". 

## Related Issue(s)
- #608 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
