### PR TITLE
Remove superfluous Sonar cache step from build workflow

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -10,7 +10,6 @@ on:
     paths:
       - 'src/**'
       - 'test/Altinn.Platform.Events.Tests/**'
-      - .github/workflows/build-and-analyze.yml
   workflow_dispatch:
 jobs:
   build-test-analyze:
@@ -32,6 +31,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
       - name: Install SonarCloud scanners
         run: |
           dotnet tool install --global dotnet-sonarscanner

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'src/**'
       - 'test/Altinn.Platform.Events.Tests/**'
+      - .github/workflows/build-and-analyze.yml
   workflow_dispatch:
 jobs:
   build-test-analyze:

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -31,12 +31,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~\sonar\cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
       - name: Install SonarCloud scanners
         run: |
           dotnet tool install --global dotnet-sonarscanner

--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -32,12 +32,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
       - name: Install SonarCloud scanners
         run: |
           dotnet tool install --global dotnet-sonarscanner


### PR DESCRIPTION
## Description
- Remove the superfluous caching of Sonar packages in the build pipeline
- Add the build workflow's path as a PR trigger for itself, so that it gets triggered for PRs that modify it

## Related Issue(s)
[#153](https://github.com/Altinn/team-core-private/issues/153) (team-core-private)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
