### PR TITLE
627 Should return Forbidden when subscribing to a resource without access

### DIFF
--- a/src/Events/Controllers/SubscriptionController.cs
+++ b/src/Events/Controllers/SubscriptionController.cs
@@ -61,6 +61,7 @@ namespace Altinn.Platform.Events.Controllers
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [Produces("application/json")]
         public async Task<ActionResult<Subscription>> Post([FromBody] SubscriptionRequestModel subscriptionRequest)
         {
@@ -108,6 +109,7 @@ namespace Altinn.Platform.Events.Controllers
         [HttpGet("{id}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces("application/json")]
         public async Task<ActionResult<Subscription>> Get(int id)
@@ -175,6 +177,7 @@ namespace Altinn.Platform.Events.Controllers
         [HttpDelete("{id}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces("application/json")]
         public async Task<ActionResult> Delete(int id)

--- a/src/Events/Services/SubscriptionService.cs
+++ b/src/Events/Services/SubscriptionService.cs
@@ -48,7 +48,7 @@ public class SubscriptionService : ISubscriptionService
         if (!await _authorization.AuthorizeConsumerForEventsSubscription(eventsSubscription))
         {
             var errorMessage = $"Not authorized to create a subscription for resource {eventsSubscription.ResourceFilter}.";
-            return (null, new ServiceError(401, errorMessage));
+            return (null, new ServiceError(403, errorMessage));
         }
 
         Subscription subscription = await _repository.FindSubscription(eventsSubscription, CancellationToken.None);
@@ -72,7 +72,7 @@ public class SubscriptionService : ISubscriptionService
 
         if (!AuthorizeAccessToSubscription(subscription))
         {
-            error = new ServiceError(401);
+            error = new ServiceError(403);
 
             return error;
         }
@@ -93,7 +93,7 @@ public class SubscriptionService : ISubscriptionService
 
         if (!AuthorizeAccessToSubscription(subscription))
         {
-            return (null, new ServiceError(401));
+            return (null, new ServiceError(403));
         }
 
         return (subscription, null);

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
@@ -84,11 +84,11 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             /// <summary>
             /// Gets a specific subscription
             /// Expected result:
-            /// Returns HttpStatus ok
+            /// Returns HttpStatus Forbidden
             /// Scenario: 
             /// </summary>
             [Fact]
-            public async Task Get_GivenSubscriptionOrganisationWithInvalidCreatedBy_ReturnsUnauthorizd()
+            public async Task Get_GivenSubscriptionOrganisationWithInvalidCreatedBy_ReturnsForbidden()
             {
                 // Arrange
                 string requestUri = $"{BasePath}/subscriptions/12";
@@ -101,7 +101,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
                 // Assert
-                Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
             }
 
             [Fact]
@@ -209,10 +209,10 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             /// <summary>
             /// Deletes a subscription that user is authorized for
             /// Expected result:
-            /// Return httpStatus ok
+            /// Return httpStatus Unauthorized
             /// </summary>
             [Fact]
-            public async Task Delete_GivenSubscriptionOrganisationWithInvalidCreatedBy_ReturnsUnAuthorized()
+            public async Task Delete_GivenSubscriptionOrganisationWithInvalidCreatedBy_ReturnsForbidden()
             {
                 // Arrange
                 string requestUri = $"{BasePath}/subscriptions/16";
@@ -224,7 +224,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
 
                 // Assert
-                Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
             }
 
             [Fact]

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
@@ -209,7 +209,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             /// <summary>
             /// Deletes a subscription that user is authorized for
             /// Expected result:
-            /// Return httpStatus Unauthorized
+            /// Return httpStatus Forbidden
             /// </summary>
             [Fact]
             public async Task Delete_GivenSubscriptionOrganisationWithInvalidCreatedBy_ReturnsForbidden()

--- a/test/Altinn.Platform.Events.Tests/TestingServices/SubscriptionServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/SubscriptionServiceTest.cs
@@ -86,7 +86,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
         }
 
         [Fact]
-        public async Task CreateSubscription_Forbidden_ReturnsError()
+        public async Task CreateSubscription_WithoutAccess_ReturnsForbiddenError()
         {
             // Arrange 
             string expectedErrorMessage = "Not authorized to create a subscription for resource urn:altinn:resource:some-service.";

--- a/test/Altinn.Platform.Events.Tests/TestingServices/SubscriptionServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/SubscriptionServiceTest.cs
@@ -86,7 +86,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
         }
 
         [Fact]
-        public async Task CreateSubscription_Unauthorized_ReturnsError()
+        public async Task CreateSubscription_Forbidden_ReturnsError()
         {
             // Arrange 
             string expectedErrorMessage = "Not authorized to create a subscription for resource urn:altinn:resource:some-service.";
@@ -103,7 +103,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             (var _, ServiceError actual) = await sut.CompleteSubscriptionCreation(input);
 
             // Assert
-            Assert.Equal(401, actual.ErrorCode);
+            Assert.Equal(403, actual.ErrorCode);
             Assert.Equal(expectedErrorMessage, actual.ErrorMessage);
         }
 


### PR DESCRIPTION


## Description
Returning error code 403 Forbidden when the provided identity does not match the identity with access to a resource

## Related Issue(s)
- #627 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
