### PR TITLE
Default to 'Warning' log filters in prod

### DIFF
--- a/src/Events/appsettings.Production.json
+++ b/src/Events/appsettings.Production.json
@@ -1,16 +1,9 @@
 {
     "Logging": {
       "LogLevel": {
-        "Default": "Debug",
-        "System": "Information",
-        "Microsoft": "Information"
-      },
-      "OpenTelemetry": {
-        "LogLevel": {
-          "Default": "Warning",
-          "System": "Warning",
-          "Microsoft": "Warning"
-        }
+        "Default": "Warning",
+        "System": "Warning",
+        "Microsoft": "Warning"
       }
     }
   }


### PR DESCRIPTION
## Description
Apparently, neither "ApplicationInsights" nor "OpenTelemetry" works as logging provider in our current setup. Until we find another way of targeting OTel/AppInsights directly, we will default to `Warning` in Production, [as in Storage](https://github.com/Altinn/altinn-storage/pull/660/files)
## Related Issue(s)
- [#136 (team-core-private)](https://github.com/orgs/Altinn/projects/20/views/11?pane=issue&itemId=94396448&issue=Altinn%7Cteam-core-private%7C136)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
