### PR TITLE
Change Events.Functions package reference to specific version

### DIFF
--- a/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
+++ b/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Upgrading to 1.1.5 will cause the function to fail, must upgrade function to .net 7 first-->
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.3" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="[1.1.3]" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />


### PR DESCRIPTION
Change Events.Functions pacakge reference to specific version of AccessTokenClient

<!--- Provide a general summary of your changes in the Title above -->

## Description
By using square brackets enclosing the version reference of a package in a project file, the package won't be updated.
https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
