### PR TITLE
Fix hard-coded activity value when creating subscription detail logs

### DIFF
--- a/src/Events.Functions/Clients/EventsClient.cs
+++ b/src/Events.Functions/Clients/EventsClient.cs
@@ -136,7 +136,7 @@ namespace Altinn.Platform.Events.Functions.Clients
         /// </summary>
         /// <param name="cloudEventEnvelope">Wrapper object for cloud event and subscriber data</param>
         /// <param name="statusCode">Http status code returned</param>
-        /// <returns></returns>
+        /// <returns>A task representing the asynchronous operation.</returns>
         public async Task LogWebhookHttpStatusCode(CloudEventEnvelope cloudEventEnvelope, HttpStatusCode statusCode)
         {
             try

--- a/src/Events.Functions/Clients/EventsClient.cs
+++ b/src/Events.Functions/Clients/EventsClient.cs
@@ -131,7 +131,12 @@ namespace Altinn.Platform.Events.Functions.Clients
             }
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Log response from webhook post to subscriber.
+        /// </summary>
+        /// <param name="cloudEventEnvelope">Wrapper object for cloud event and subscriber data</param>
+        /// <param name="statusCode">Http status code returned</param>
+        /// <returns></returns>
         public async Task LogWebhookHttpStatusCode(CloudEventEnvelope cloudEventEnvelope, HttpStatusCode statusCode)
         {
             try

--- a/src/Events/Services/TraceLogService.cs
+++ b/src/Events/Services/TraceLogService.cs
@@ -66,9 +66,9 @@ namespace Altinn.Platform.Events.Services
                     Resource = cloudEvent.GetResource(),
                     EventType = cloudEvent.Type,
                     Consumer = subscription.Consumer,
-                    SubscriberEndpoint = null, // not relevant when unauthorized
+                    SubscriberEndpoint = subscription.EndPoint?.ToString(),
                     SubscriptionId = subscription.Id,
-                    Activity = TraceLogActivity.Unauthorized
+                    Activity = activity
                 };
 
                 await _traceLogRepository.CreateTraceLogEntry(traceLogEntry);


### PR DESCRIPTION
In certain cases where activity should have been 'outboundQueue', the value was overridden and set to 'unauthorized'.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #658 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
