### PR TITLE
Move register lookup from EventsService to AuthorizationService

### DIFF
--- a/src/Events/Controllers/EventsController.cs
+++ b/src/Events/Controllers/EventsController.cs
@@ -127,7 +127,7 @@ namespace Altinn.Platform.Events.Controllers
             {
                 if (tce.CancellationToken.IsCancellationRequested)
                 {
-                    return Problem(tce.StackTrace, null, 499, tce.Message);
+                    return Problem(null, null, 499, "Cancellation was requested.");
                 }
 
                 throw;

--- a/src/Events/Services/AuthorizationService.cs
+++ b/src/Events/Services/AuthorizationService.cs
@@ -23,7 +23,7 @@ using CloudNative.CloudEvents;
 namespace Altinn.Platform.Events.Services;
 
 /// <summary>
-/// The authorization service
+/// An implementation of the <see cref="IAuthorization"/> interface that handles authorization for events.
 /// </summary>
 public class AuthorizationService : IAuthorization
 {
@@ -33,8 +33,8 @@ public class AuthorizationService : IAuthorization
     /// <summary>
     /// Initializes a new instance of the <see cref="AuthorizationService"/> class with provided dependencies.
     /// </summary>
-    /// <param name="pdp">The policy decision point</param>
-    /// <param name="claimsPrincipalProvider">A service</param>
+    /// <param name="pdp">A client implementation for policy decision point.</param>
+    /// <param name="claimsPrincipalProvider">A service that can provide the ClaimsPrincipal for active user.</param>
     public AuthorizationService(
         IPDP pdp, 
         IClaimsPrincipalProvider claimsPrincipalProvider)

--- a/src/Events/Services/AuthorizationService.cs
+++ b/src/Events/Services/AuthorizationService.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -5,9 +7,11 @@ using System.Threading.Tasks;
 
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+
 using Altinn.Common.PEP.Constants;
 using Altinn.Common.PEP.Helpers;
 using Altinn.Common.PEP.Interfaces;
+
 using Altinn.Platform.Events.Authorization;
 using Altinn.Platform.Events.Configuration;
 using Altinn.Platform.Events.Extensions;
@@ -16,124 +20,125 @@ using Altinn.Platform.Events.Services.Interfaces;
 
 using CloudNative.CloudEvents;
 
-namespace Altinn.Platform.Events.Services
+namespace Altinn.Platform.Events.Services;
+
+/// <summary>
+/// The authorization service
+/// </summary>
+public class AuthorizationService : IAuthorization
 {
+    private readonly IPDP _pdp;
+    private readonly IClaimsPrincipalProvider _claimsPrincipalProvider;
+
     /// <summary>
-    /// The authorization service
+    /// Initializes a new instance of the <see cref="AuthorizationService"/> class with provided dependencies.
     /// </summary>
-    public class AuthorizationService : IAuthorization
+    /// <param name="pdp">The policy decision point</param>
+    /// <param name="claimsPrincipalProvider">A service</param>
+    public AuthorizationService(
+        IPDP pdp, 
+        IClaimsPrincipalProvider claimsPrincipalProvider)
     {
-        private readonly IPDP _pdp;
-        private readonly IClaimsPrincipalProvider _claimsPrincipalProvider;
+        _pdp = pdp;
+        _claimsPrincipalProvider = claimsPrincipalProvider;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthorizationService"/> class.
-        /// </summary>
-        /// <param name="pdp">The policy decision point</param>
-        /// <param name="claimsPrincipalProvider">The claims principal provider</param>
-        public AuthorizationService(IPDP pdp, IClaimsPrincipalProvider claimsPrincipalProvider)
+    /// <inheritdoc/>
+    public async Task<List<CloudEvent>> AuthorizeAltinnAppEvents(List<CloudEvent> cloudEvents)
+    {
+        ClaimsPrincipal consumer = _claimsPrincipalProvider.GetUser();
+        XacmlJsonRequestRoot xacmlJsonRequest = AppCloudEventXacmlMapper.CreateMultiDecisionReadRequest(consumer, cloudEvents);
+        XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
+
+        return FilterAuthorizedRequests(cloudEvents, consumer, response);
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<CloudEvent>> AuthorizeEvents(List<CloudEvent> cloudEvents)
+    {
+        ClaimsPrincipal consumer = _claimsPrincipalProvider.GetUser();
+
+        XacmlJsonRequestRoot xacmlJsonRequest = GenericCloudEventXacmlMapper.CreateMultiDecisionRequest(consumer, "subscribe", cloudEvents);
+        XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
+
+        return FilterAuthorizedRequests(cloudEvents, consumer, response);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> AuthorizePublishEvent(CloudEvent cloudEvent)
+    {
+        ClaimsPrincipal consumer = _claimsPrincipalProvider.GetUser();
+
+        if (consumer.HasRequiredScope(AuthorizationConstants.SCOPE_EVENTS_ADMIN_PUBLISH))
         {
-            _pdp = pdp;
-            _claimsPrincipalProvider = claimsPrincipalProvider;
+            return true;
         }
 
-        /// <inheritdoc/>
-        public async Task<List<CloudEvent>> AuthorizeAltinnAppEvents(List<CloudEvent> cloudEvents)
-        {
-            ClaimsPrincipal consumer = _claimsPrincipalProvider.GetUser();
-            XacmlJsonRequestRoot xacmlJsonRequest = AppCloudEventXacmlMapper.CreateMultiDecisionReadRequest(consumer, cloudEvents);
-            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
+        XacmlJsonRequestRoot xacmlJsonRequest = GenericCloudEventXacmlMapper.CreateDecisionRequest(consumer, "publish", cloudEvent);
+        XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
 
-            return FilterAuthorizedRequests(cloudEvents, consumer, response);
+        return IsPermit(response);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> AuthorizeConsumerForGenericEvent(CloudEvent cloudEvent, string consumer)
+    {
+        XacmlJsonRequestRoot xacmlJsonRequest = GenericCloudEventXacmlMapper.CreateDecisionRequest(consumer, "subscribe", cloudEvent);
+        XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
+        return IsPermit(response);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> AuthorizeConsumerForAltinnAppEvent(CloudEvent cloudEvent, string consumer)
+    {
+        XacmlJsonRequestRoot xacmlJsonRequest = AppCloudEventXacmlMapper.CreateDecisionRequest(cloudEvent, consumer);
+        XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
+        return IsPermit(response);
+    }
+   
+    /// <inheritdoc/>
+    public async Task<bool> AuthorizeConsumerForEventsSubscription(Subscription subscription)
+    {
+        XacmlJsonRequestRoot xacmlJsonRequest = SubscriptionXacmlMapper.CreateDecisionRequest(subscription);
+        XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
+        return IsPermit(response);
+    }
+
+    private static bool IsPermit(XacmlJsonResponse response)
+    {
+        if (response.Response[0].Decision.Equals(XacmlContextDecision.Permit.ToString()))
+        {
+            return true;
         }
 
-        /// <inheritdoc/>
-        public async Task<List<CloudEvent>> AuthorizeEvents(List<CloudEvent> cloudEvents)
+        return false;
+    }
+
+    /// <summary>
+    /// Composes a list of events that the consumer is authorized to receive based on the provided xacml response
+    /// </summary>
+    internal static List<CloudEvent> FilterAuthorizedRequests(List<CloudEvent> cloudEvents, ClaimsPrincipal consumer, XacmlJsonResponse response)
+    {
+        List<CloudEvent> authorizedEventsList = [];
+
+        foreach (XacmlJsonResult result in response.Response.Where(result => DecisionHelper.ValidateDecisionResult(result, consumer)))
         {
-            ClaimsPrincipal consumer = _claimsPrincipalProvider.GetUser();
+            string eventId = string.Empty;
 
-            XacmlJsonRequestRoot xacmlJsonRequest = GenericCloudEventXacmlMapper.CreateMultiDecisionRequest(consumer, "subscribe", cloudEvents);
-            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
-
-            return FilterAuthorizedRequests(cloudEvents, consumer, response);
-        }
-
-        /// <inheritdoc/>
-        public async Task<bool> AuthorizePublishEvent(CloudEvent cloudEvent)
-        {
-            ClaimsPrincipal consumer = _claimsPrincipalProvider.GetUser();
-
-            if (consumer.HasRequiredScope(AuthorizationConstants.SCOPE_EVENTS_ADMIN_PUBLISH))
+            // Loop through all attributes in Category from the response
+            foreach (var attributes in result.Category.Select(category => category.Attribute))
             {
-                return true;
-            }
-
-            XacmlJsonRequestRoot xacmlJsonRequest = GenericCloudEventXacmlMapper.CreateDecisionRequest(consumer, "publish", cloudEvent);
-            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
-
-            return ValidateResult(response);
-        }
-
-        /// <inheritdoc/>
-        public async Task<bool> AuthorizeConsumerForGenericEvent(CloudEvent cloudEvent, string consumer)
-        {
-            XacmlJsonRequestRoot xacmlJsonRequest = GenericCloudEventXacmlMapper.CreateDecisionRequest(consumer, "subscribe", cloudEvent);
-            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
-            return ValidateResult(response);
-        }
-
-        /// <inheritdoc/>
-        public async Task<bool> AuthorizeConsumerForAltinnAppEvent(CloudEvent cloudEvent, string consumer)
-        {
-            XacmlJsonRequestRoot xacmlJsonRequest = AppCloudEventXacmlMapper.CreateDecisionRequest(cloudEvent, consumer);
-            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
-            return ValidateResult(response);
-        }
-       
-        /// <inheritdoc/>
-        public async Task<bool> AuthorizeConsumerForEventsSubscription(Subscription subscription)
-        {
-            XacmlJsonRequestRoot xacmlJsonRequest = SubscriptionXacmlMapper.CreateDecisionRequest(subscription);
-            XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
-            return ValidateResult(response);
-        }
-
-        private static bool ValidateResult(XacmlJsonResponse response)
-        {
-            if (response.Response[0].Decision.Equals(XacmlContextDecision.Permit.ToString()))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Composes a list of events that the consumer is authorized to receive based on the provided xacml response
-        /// </summary>
-        internal static List<CloudEvent> FilterAuthorizedRequests(List<CloudEvent> cloudEvents, ClaimsPrincipal consumer, XacmlJsonResponse response)
-        {
-            List<CloudEvent> authorizedEventsList = [];
-
-            foreach (XacmlJsonResult result in response.Response.Where(result => DecisionHelper.ValidateDecisionResult(result, consumer)))
-            {
-                string eventId = string.Empty;
-
-                // Loop through all attributes in Category from the response
-                foreach (var attributes in result.Category.Select(category => category.Attribute))
+                foreach (var attribute in attributes.Where(attribute => attribute.AttributeId.Equals(AltinnXacmlUrns.EventId)))
                 {
-                    foreach (var attribute in attributes.Where(attribute => attribute.AttributeId.Equals(AltinnXacmlUrns.EventId)))
-                    {
-                        eventId = attribute.Value;
-                    }
+                    eventId = attribute.Value;
                 }
-
-                // Find the instance that has been validated to add it to the list of authorized instances.
-                CloudEvent authorizedEvent = cloudEvents.First(i => i.Id == eventId);
-                authorizedEventsList.Add(authorizedEvent);
             }
 
-            return authorizedEventsList;
+            // Find the instance that has been validated to add it to the list of authorized instances.
+            CloudEvent authorizedEvent = cloudEvents.First(i => i.Id == eventId);
+            authorizedEventsList.Add(authorizedEvent);
         }
+
+        return authorizedEventsList;
     }
 }

--- a/src/Events/Services/EventsService.cs
+++ b/src/Events/Services/EventsService.cs
@@ -21,8 +21,6 @@ namespace Altinn.Platform.Events.Services
     /// </summary>
     public class EventsService : IEventsService
     {
-        private const string _originalSubjectKey = "originalsubjectreplacedforauthorization";
-
         private readonly ICloudEventRepository _repository;
         private readonly ITraceLogService _traceLogService;
         private readonly IEventsQueueClient _queueClient;
@@ -138,57 +136,7 @@ namespace Altinn.Platform.Events.Services
                 return events;
             }
 
-            /********
-             * Authorization doesn't support event subject on the format urn:altinn:person:identifier-no:08895699684.
-             * We need to obtain the party UUID from Register and use that instead when building the authorization request.
-             *******/
-
-            List<string> subjects = events
-                .Where(e => e.Subject.StartsWith("urn:altinn:person:identifier-no:"))
-                .Select(e => e.Subject)
-                .Distinct()
-                .ToList();
-
-            if (subjects.Count == 0)
-            {
-                return await _authorizationService.AuthorizeEvents(events);
-            }
-
-            IEnumerable<PartyIdentifiers> partyIdentifiersList = await _registerService.PartyLookup(subjects, cancellationToken);
-
-            foreach (CloudEvent cloudEvent in events.Where(e => e.Subject.StartsWith("urn:altinn:person:identifier-no:")))
-            {
-                cloudEvent[_originalSubjectKey] = cloudEvent.Subject;
-                    
-                string nationalIdentityNumber = cloudEvent.Subject.Split(":")[4];
-
-                PartyIdentifiers partyIdentifiers = 
-                    partyIdentifiersList.FirstOrDefault(p => p.PersonIdentifier == nationalIdentityNumber);
-
-                if (partyIdentifiers != null)
-                {
-                    cloudEvent.Subject = $"urn:altinn:party:uuid:{partyIdentifiers.PartyUuid}";
-                }
-                else
-                {
-                    // If the party is not found in register, it's a data quality issue across systems.
-                    // For example a difference in the data between Dialogporten and Register.
-                    cloudEvent.Subject = null;
-                }
-            }
-
-            List<CloudEvent> authorizedEvents = await _authorizationService.AuthorizeEvents(events);
-
-            foreach (CloudEvent cloudEvent in authorizedEvents)
-            {
-                if (cloudEvent[_originalSubjectKey] != null)
-                {
-                    cloudEvent.Subject = cloudEvent[_originalSubjectKey].ToString();
-                    cloudEvent[_originalSubjectKey] = null;
-                }
-            }
-
-            return authorizedEvents;
+            return await _authorizationService.AuthorizeEvents(events, cancellationToken);
         }
     }
 }

--- a/src/Events/Services/Interfaces/IAuthorization.cs
+++ b/src/Events/Services/Interfaces/IAuthorization.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Events.Models;
@@ -23,8 +24,12 @@ namespace Altinn.Platform.Events.Services.Interfaces
         /// Authorizes and filters events based on authorization
         /// </summary>
         /// <param name="cloudEvents">The list of events</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
+        /// </param>
         /// <returns>A list of authorized events</returns>
-        public Task<List<CloudEvent>> AuthorizeEvents(List<CloudEvent> cloudEvents);
+        public Task<List<CloudEvent>> AuthorizeEvents(
+            IEnumerable<CloudEvent> cloudEvents, CancellationToken cancellationToken);
 
         /// <summary>
         /// Authorizes the currents user's right to publish the provided event

--- a/test/Altinn.Platform.Events.Tests/Data/XacmlJsonResponse/permit_five.json
+++ b/test/Altinn.Platform.Events.Tests/Data/XacmlJsonResponse/permit_five.json
@@ -1,0 +1,289 @@
+﻿{
+  "Response": [
+    {
+      "Decision": "Permit",
+      "Status": {
+        "StatusMessage": null,
+        "StatusDetails": null,
+        "StatusCode": {
+          "Value": "urn:oasis:names:tc:xacml:1.0:status:ok",
+          "StatusCode": null
+        }
+      },
+      "Obligations": [
+        {
+          "Id": "urn:altinn:obligation:1",
+          "AttributeAssignment": [
+            {
+              "AttributeId": "urn:altinn:obligation-assignment:1",
+              "Value": "2",
+              "Category": "urn:altinn:minimum-authenticationlevel",
+              "DataType": "http://www.w3.org/2001/XMLSchema#integer",
+              "Issuer": null
+            }
+          ]
+        }
+      ],
+      "AssociateAdvice": null,
+      "Category": [
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+              "Value": "subscribe",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        },
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:resource",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:altinn:event-id",
+              "Value": "99253099-eeac-4ca3-b758-350fcde53356",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        }
+      ],
+      "PolicyIdentifierList": null
+    },
+    {
+      "Decision": "Permit",
+      "Status": {
+        "StatusMessage": null,
+        "StatusDetails": null,
+        "StatusCode": {
+          "Value": "urn:oasis:names:tc:xacml:1.0:status:ok",
+          "StatusCode": null
+        }
+      },
+      "Obligations": [
+        {
+          "Id": "urn:altinn:obligation:1",
+          "AttributeAssignment": [
+            {
+              "AttributeId": "urn:altinn:obligation-assignment:1",
+              "Value": "2",
+              "Category": "urn:altinn:minimum-authenticationlevel",
+              "DataType": "http://www.w3.org/2001/XMLSchema#integer",
+              "Issuer": null
+            }
+          ]
+        }
+      ],
+      "AssociateAdvice": null,
+      "Category": [
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+              "Value": "subscribe",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        },
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:resource",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:altinn:event-id",
+              "Value": "b8902f90-0b5b-42c2-9841-954f3c031f05",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        }
+      ],
+      "PolicyIdentifierList": null
+    },
+    {
+      "Decision": "Permit",
+      "Status": {
+        "StatusMessage": null,
+        "StatusDetails": null,
+        "StatusCode": {
+          "Value": "urn:oasis:names:tc:xacml:1.0:status:ok",
+          "StatusCode": null
+        }
+      },
+      "Obligations": [
+        {
+          "Id": "urn:altinn:obligation:1",
+          "AttributeAssignment": [
+            {
+              "AttributeId": "urn:altinn:obligation-assignment:1",
+              "Value": "2",
+              "Category": "urn:altinn:minimum-authenticationlevel",
+              "DataType": "http://www.w3.org/2001/XMLSchema#integer",
+              "Issuer": null
+            }
+          ]
+        }
+      ],
+      "AssociateAdvice": null,
+      "Category": [
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+              "Value": "subscribe",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        },
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:resource",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:altinn:event-id",
+              "Value": "3d7b17ad-a53e-47ca-8cfb-2b2a72a37804",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        }
+      ],
+      "PolicyIdentifierList": null
+    },
+    {
+      "Decision": "Permit",
+      "Status": {
+        "StatusMessage": null,
+        "StatusDetails": null,
+        "StatusCode": {
+          "Value": "urn:oasis:names:tc:xacml:1.0:status:ok",
+          "StatusCode": null
+        }
+      },
+      "Obligations": [
+        {
+          "Id": "urn:altinn:obligation:1",
+          "AttributeAssignment": [
+            {
+              "AttributeId": "urn:altinn:obligation-assignment:1",
+              "Value": "2",
+              "Category": "urn:altinn:minimum-authenticationlevel",
+              "DataType": "http://www.w3.org/2001/XMLSchema#integer",
+              "Issuer": null
+            }
+          ]
+        }
+      ],
+      "AssociateAdvice": null,
+      "Category": [
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+              "Value": "subscribe",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        },
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:resource",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:altinn:event-id",
+              "Value": "81d89359-373a-48d3-af5c-44aa378ba97f",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        }
+      ],
+      "PolicyIdentifierList": null
+    },
+    {
+      "Decision": "Permit",
+      "Status": {
+        "StatusMessage": null,
+        "StatusDetails": null,
+        "StatusCode": {
+          "Value": "urn:oasis:names:tc:xacml:1.0:status:ok",
+          "StatusCode": null
+        }
+      },
+      "Obligations": [
+        {
+          "Id": "urn:altinn:obligation:1",
+          "AttributeAssignment": [
+            {
+              "AttributeId": "urn:altinn:obligation-assignment:1",
+              "Value": "2",
+              "Category": "urn:altinn:minimum-authenticationlevel",
+              "DataType": "http://www.w3.org/2001/XMLSchema#integer",
+              "Issuer": null
+            }
+          ]
+        }
+      ],
+      "AssociateAdvice": null,
+      "Category": [
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+              "Value": "subscribe",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        },
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:resource",
+          "Id": null,
+          "Content": null,
+          "Attribute": [
+            {
+              "AttributeId": "urn:altinn:event-id",
+              "Value": "ef4c26b2-4ea6-4914-851b-560bc1b33cff",
+              "Issuer": null,
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "IncludeInResult": false
+            }
+          ]
+        }
+      ],
+      "PolicyIdentifierList": null
+    }
+  ]
+}

--- a/test/Altinn.Platform.Events.Tests/Data/XacmlJsonResponse/permit_five.json
+++ b/test/Altinn.Platform.Events.Tests/Data/XacmlJsonResponse/permit_five.json
@@ -47,7 +47,7 @@
           "Attribute": [
             {
               "AttributeId": "urn:altinn:event-id",
-              "Value": "99253099-eeac-4ca3-b758-350fcde53356",
+              "Value": "e7c581bc-e931-46c8-bfc0-3c6716d8da15",
               "Issuer": null,
               "DataType": "http://www.w3.org/2001/XMLSchema#string",
               "IncludeInResult": false
@@ -104,7 +104,7 @@
           "Attribute": [
             {
               "AttributeId": "urn:altinn:event-id",
-              "Value": "b8902f90-0b5b-42c2-9841-954f3c031f05",
+              "Value": "ef14212c-0f9d-4f88-89c5-255d946e5f18",
               "Issuer": null,
               "DataType": "http://www.w3.org/2001/XMLSchema#string",
               "IncludeInResult": false
@@ -161,7 +161,7 @@
           "Attribute": [
             {
               "AttributeId": "urn:altinn:event-id",
-              "Value": "3d7b17ad-a53e-47ca-8cfb-2b2a72a37804",
+              "Value": "29168d79-b081-4299-9eec-2db9b5259fac",
               "Issuer": null,
               "DataType": "http://www.w3.org/2001/XMLSchema#string",
               "IncludeInResult": false
@@ -218,7 +218,7 @@
           "Attribute": [
             {
               "AttributeId": "urn:altinn:event-id",
-              "Value": "81d89359-373a-48d3-af5c-44aa378ba97f",
+              "Value": "bf1411fe-c55e-4472-9f37-10e2c2403ecb",
               "Issuer": null,
               "DataType": "http://www.w3.org/2001/XMLSchema#string",
               "IncludeInResult": false
@@ -275,7 +275,7 @@
           "Attribute": [
             {
               "AttributeId": "urn:altinn:event-id",
-              "Value": "ef4c26b2-4ea6-4914-851b-560bc1b33cff",
+              "Value": "95d53441-5ecf-4165-83d8-a757afd8a7e2",
               "Issuer": null,
               "DataType": "http://www.w3.org/2001/XMLSchema#string",
               "IncludeInResult": false

--- a/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+
 using Altinn.Common.PEP.Interfaces;
+
 using Altinn.Platform.Events.Services;
 using Altinn.Platform.Events.Services.Interfaces;
 using Altinn.Platform.Events.Tests.Utils;
@@ -26,6 +29,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
     {
         private readonly CloudEvent _cloudEvent;
         private readonly Mock<IClaimsPrincipalProvider> _principalMock = new();
+        private readonly Mock<IRegisterService> _registerServiceMock = new();
 
         public AuthorizationServiceTest()
         {
@@ -50,7 +54,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
         public async Task AuthorizeConsumerForAltinnAppEvent_Self()
         {
             PepWithPDPAuthorizationMockSI pdp = new PepWithPDPAuthorizationMockSI();
-            AuthorizationService authzHelper = new AuthorizationService(pdp, _principalMock.Object);
+            AuthorizationService authzHelper = 
+                new AuthorizationService(pdp, _principalMock.Object, _registerServiceMock.Object);
 
             // Act
             bool result = await authzHelper.AuthorizeConsumerForAltinnAppEvent(_cloudEvent, "/user/1337");
@@ -66,7 +71,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
         public async Task AuthorizeConsumerForAltinnAppEvent_OrgAccessToEventForUser()
         {
             PepWithPDPAuthorizationMockSI pdp = new PepWithPDPAuthorizationMockSI();
-            AuthorizationService authzHelper = new AuthorizationService(pdp, _principalMock.Object);
+            AuthorizationService authzHelper = 
+                new AuthorizationService(pdp, _principalMock.Object, _registerServiceMock.Object);
 
             // Act
             bool result = await authzHelper.AuthorizeConsumerForAltinnAppEvent(_cloudEvent, "/org/ttd");
@@ -82,7 +88,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
         public async Task AuthorizeConsumerForAltinnAppEvent_OrgAccessToEventForUserNotAuthorized()
         {
             PepWithPDPAuthorizationMockSI pdp = new PepWithPDPAuthorizationMockSI();
-            AuthorizationService authzHelper = new AuthorizationService(pdp, _principalMock.Object);
+            AuthorizationService authzHelper = 
+                new AuthorizationService(pdp, _principalMock.Object, _registerServiceMock.Object);
 
             CloudEvent cloudEvent = new()
             {
@@ -103,8 +110,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             // Arrange
             Mock<IPDP> pdpMock = GetPDPMockWithRespose("Permit");
 
-            // Act            
-            var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object);
+            // Act
+            var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object, _registerServiceMock.Object);
 
             bool actual = await sut.AuthorizeConsumerForGenericEvent(_cloudEvent, "/org/ttd/");
 
@@ -122,7 +129,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             List<CloudEvent> cloudEvents = TestdataUtil.GetXacmlRequestCloudEventList();
             XacmlJsonResponse response = TestdataUtil.GetXacmlJsonResponse(testCase);
 
-            // Act            
+            // Act
             List<CloudEvent> actual = AuthorizationService.FilterAuthorizedRequests(cloudEvents, consumer, response);
 
             // Assert
@@ -139,7 +146,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             List<CloudEvent> cloudEvents = TestdataUtil.GetXacmlRequestCloudEventList();
             XacmlJsonResponse response = TestdataUtil.GetXacmlJsonResponse(testCase);
 
-            // Act            
+            // Act
             List<CloudEvent> actual = AuthorizationService.FilterAuthorizedRequests(cloudEvents, consumer, response);
 
             // Assert
@@ -155,7 +162,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             List<CloudEvent> cloudEvents = TestdataUtil.GetXacmlRequestCloudEventList();
             ClaimsPrincipal consumer = PrincipalUtil.GetSystemUserPrincipal("system_identifier", "9485C31D-6ECE-477F-B81C-1E2593FC1309", "random_org", 3);
 
-            // Act            
+            // Act
             List<CloudEvent> actual = AuthorizationService.FilterAuthorizedRequests(cloudEvents, consumer, response);
 
             // Assert
@@ -169,8 +176,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             // Arrange
             Mock<IPDP> pdpMock = GetPDPMockWithRespose("Permit");
 
-            // Act            
-            var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object);
+            // Act
+            var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object, _registerServiceMock.Object);
 
             bool actual = await sut.AuthorizePublishEvent(_cloudEvent);
 
@@ -185,8 +192,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             // Arrange
             Mock<IPDP> pdpMock = GetPDPMockWithRespose("Deny");
 
-            // Act            
-            var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object);
+            // Act
+            var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object, _registerServiceMock.Object);
 
             bool actual = await sut.AuthorizePublishEvent(_cloudEvent);
 
@@ -201,8 +208,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             // Arrange
             Mock<IPDP> pdpMock = GetPDPMockWithRespose("Indeterminate");
 
-            // Act            
-            var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object);
+            // Act
+            var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object, _registerServiceMock.Object);
 
             bool actual = await sut.AuthorizePublishEvent(_cloudEvent);
 
@@ -221,7 +228,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
                 .Returns(PrincipalUtil.GetClaimsPrincipal("digdir", "912345678", "altinn:events.publish.admin", "AuthenticationTypes.Federation"));
 
             // Act
-            var sut = new AuthorizationService(pdpMock.Object, principalMock.Object);
+            var sut = new AuthorizationService(pdpMock.Object, principalMock.Object, _registerServiceMock.Object);
 
             bool actual = await sut.AuthorizePublishEvent(_cloudEvent);
 
@@ -240,12 +247,111 @@ namespace Altinn.Platform.Events.Tests.TestingServices
                 .Returns(PrincipalUtil.GetClaimsPrincipal("digdir", "912345678", "somerandomprefix:altinn:events.publish.admin", "AuthenticationTypes.Federation"));
 
             // Act
-            var sut = new AuthorizationService(pdpMock.Object, principalMock.Object);
+            var sut = new AuthorizationService(pdpMock.Object, principalMock.Object, _registerServiceMock.Object);
 
             bool actual = await sut.AuthorizePublishEvent(_cloudEvent);
 
             // Assert
             Assert.False(actual);
+        }
+
+        [Fact]
+        public async Task AuthorizeEvents_InputEventsFiveSubjects_LogicManipluateSubjectCorrectly()
+        {
+            List<CloudEvent> cloudEvents = [
+                GetCloudEvent("urn:altinn:resource:super-simple-service", "urn:altinn:person:identifier-no:02056241046"),
+                GetCloudEvent("urn:altinn:resource:super-simple-service", "urn:altinn:organization:identifier-no:312508729"),
+                GetCloudEvent("urn:altinn:resource:super-simple-service", "urn:altinn:person:identifier-no:31073102351"),
+                GetCloudEvent("urn:altinn:resource:super-simple-service", "urn:altinn:person:identifier-no:31073102351"),
+                GetCloudEvent("urn:altinn:resource:super-simple-service", "urn:altinn:person:identifier-no:notfound")];
+
+            List<PartyIdentifiers> partyIdentifiers =
+                (await TestDataLoader.Load<PartiesRegisterQueryResponse>("twopersons")).Data;
+
+            Mock<IRegisterService> registerMock = new();
+            registerMock.Setup(r => r.PartyLookup(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+                .Callback((IEnumerable<string> requestedUrnList, CancellationToken cancellationToken) =>
+                {
+                    Assert.Equal(3, requestedUrnList.Count());
+                    Assert.Equal("urn:altinn:person:identifier-no:02056241046", requestedUrnList.ElementAt(0));
+                    Assert.Equal("urn:altinn:person:identifier-no:31073102351", requestedUrnList.ElementAt(1));
+                    Assert.Equal("urn:altinn:person:identifier-no:notfound", requestedUrnList.ElementAt(2));
+                })
+                .ReturnsAsync(partyIdentifiers);
+
+            Mock<IPDP> pdpMock = new();
+            pdpMock
+                .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+                .Callback((XacmlJsonRequestRoot authRequest) =>
+                {
+                    List<XacmlJsonCategory> resources = authRequest.Request.Resource;
+
+                    // Analyze the generated resources with focus on the manipulated subjects
+                    Assert.Equal(5, resources.Count);
+
+                    Assert.Equal("urn:altinn:party:uuid", resources[0].Attribute[4].AttributeId);
+                    Assert.Equal("8be970b6-b361-42c6-9b53-5cd3ab5efbe9", resources[0].Attribute[4].Value);
+
+                    Assert.Equal("urn:altinn:organization:identifier-no", resources[1].Attribute[4].AttributeId);
+                    Assert.Equal("312508729", resources[1].Attribute[4].Value);
+
+                    Assert.Equal("urn:altinn:party:uuid", resources[2].Attribute[4].AttributeId);
+                    Assert.Equal("930423fe-8bbd-43f0-bf4c-3ddf5a5eb4e7", resources[2].Attribute[4].Value);
+
+                    Assert.Equal("urn:altinn:party:uuid", resources[3].Attribute[4].AttributeId);
+                    Assert.Equal("930423fe-8bbd-43f0-bf4c-3ddf5a5eb4e7", resources[3].Attribute[4].Value);
+
+                    Assert.Equal(4, resources[4].Attribute.Count); // No party identifier found
+                })
+                .ReturnsAsync(new XacmlJsonResponse
+                {
+                    Response =
+                    [
+                        new XacmlJsonResult
+                        {
+                            Decision = "Permit"
+                        }
+                    ]
+                });
+
+            AuthorizationService target = new(pdpMock.Object, _principalMock.Object, registerMock.Object);
+
+            // Act
+            List<CloudEvent> finalCloudEvents = await target.AuthorizeEvents(cloudEvents, CancellationToken.None);
+
+            Assert.NotNull(finalCloudEvents);
+
+            Assert.Equal(5, finalCloudEvents.Count);
+            Assert.StartsWith("urn:altinn:person:identifier-no:02056241046", finalCloudEvents[0].Subject);
+            Assert.Null(finalCloudEvents[0]["originalsubjectreplacedforauthorization"]);
+
+            Assert.StartsWith("urn:altinn:organization:identifier-no:", finalCloudEvents[1].Subject);
+            Assert.Null(finalCloudEvents[1]["originalsubjectreplacedforauthorization"]);
+
+            Assert.Equal("urn:altinn:person:identifier-no:31073102351", finalCloudEvents[2].Subject);
+            Assert.Null(finalCloudEvents[2]["originalsubjectreplacedforauthorization"]);
+
+            Assert.Equal("urn:altinn:person:identifier-no:31073102351", finalCloudEvents[3].Subject);
+            Assert.Null(finalCloudEvents[3]["originalsubjectreplacedforauthorization"]);
+
+            Assert.Equal("urn:altinn:person:identifier-no:notfound", finalCloudEvents[4].Subject);
+            Assert.Null(finalCloudEvents[4]["originalsubjectreplacedforauthorization"]);
+        }
+
+        private static CloudEvent GetCloudEvent(string resource, string subject)
+        {
+            CloudEvent cloudEvent = new(CloudEventsSpecVersion.V1_0)
+            {
+                Id = Guid.NewGuid().ToString(),
+                Type = "something.important.happened",
+                Time = DateTime.Now,
+                Subject = subject,
+                Source = new Uri($"https://dialogporten.no/api/v1/dialogs/{Guid.NewGuid()}")
+            };
+
+            cloudEvent["resource"] = resource;
+
+            return cloudEvent;
         }
 
         private static Mock<IPDP> GetPDPMockWithRespose(string decision)

--- a/test/Altinn.Platform.Events.Tests/TestingServices/OutboundServiceTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/OutboundServiceTests.cs
@@ -303,8 +303,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             if (authorizationMock == null)
             {
                 Mock<IClaimsPrincipalProvider> claimsPrincipalMock = new Mock<IClaimsPrincipalProvider>();
+                Mock<IRegisterService> registerServiceMock = new Mock<IRegisterService>();
 
-                authorizationMock = new AuthorizationService(new PepWithPDPAuthorizationMockSI(), claimsPrincipalMock.Object);
+                authorizationMock = new AuthorizationService(new PepWithPDPAuthorizationMockSI(), claimsPrincipalMock.Object, registerServiceMock.Object);
             }
 
             if (memoryCache == null)

--- a/test/Altinn.Platform.Events.Tests/TestingServices/RegisterServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/RegisterServiceTest.cs
@@ -14,9 +14,9 @@ using Altinn.Platform.Events.Configuration;
 using Altinn.Platform.Events.Exceptions;
 using Altinn.Platform.Events.Services;
 using Altinn.Platform.Events.Tests.Mocks;
+using Altinn.Platform.Events.Tests.Utils;
 using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
-using Altinn.Profile.Tests.Testdata;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;

--- a/test/Altinn.Platform.Events.Tests/Utils/TestDataLoader.cs
+++ b/test/Altinn.Platform.Events.Tests/Utils/TestDataLoader.cs
@@ -2,7 +2,7 @@
 using System.Text.Json;
 using System.Threading.Tasks;
 
-namespace Altinn.Profile.Tests.Testdata;
+namespace Altinn.Platform.Events.Tests.Utils;
 
 public static class TestDataLoader
 {
@@ -17,7 +17,7 @@ public static class TestDataLoader
 
         if (!File.Exists(path))
         {
-            return default(T);
+            return default;
         }
 
         string fileContent = await File.ReadAllTextAsync(path);


### PR DESCRIPTION
## Description
The purpose of this change is to prepare AuthorizationService for more changes. The related issue will require more lookup calls against Register in order to obtain a replacement value for national identity number.

## Related Issue(s)
- #704 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

