### PR TITLE
Use correct name of auth cookie from Altinn ii

### DIFF
--- a/test/k6/src/config.js
+++ b/test/k6/src/config.js
@@ -16,13 +16,13 @@ var maskinportenBaseUrls = {
 // Auth cookie names in the different environments. NB: Must be updated until changes
 // are rolled out to all environments
 export var authCookieNames = {
-  at21: '.ASPXAUTH', // '.AspxAuthCloud',
+  at21: '.AspxAuthCloud',
   at22: '.AspxAuthCloud',
-  at23: '.ASPXAUTH', // '.AspxAuthCloud',
+  at23: '.AspxAuthCloud',
   at24: '.AspxAuthCloud',
   tt02: '.AspxAuthTT02',
-  yt01: '.ASPXAUTH', // '.AspxAuthYt',
-  prod: '.ASPXAUTH', // '.AspxAuthProd'
+  yt01: '.AspxAuthYt',
+  prod: '.AspxAuthProd',
 };
 
 //Get values from environment


### PR DESCRIPTION
## Description
Update use-case tests to use correct auth cookie name when performing login of a user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated authentication cookie names for several environments to reflect new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->