### PR TITLE
Revert "chore(deps): update nuget non-major dependencies"

### DIFF
--- a/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
+++ b/src/Events.Functions/Altinn.Platform.Events.Functions.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <!-- Upgrading to 1.1.5 will cause the function to fail, must upgrade function to .net 7 first-->
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="[1.1.3]" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />

--- a/test/Altinn.Platform.Events.Functions.Tests/Altinn.Platform.Events.Functions.Tests.csproj
+++ b/test/Altinn.Platform.Events.Functions.Tests/Altinn.Platform.Events.Functions.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.36" />
-    <!-- Upgrading to 17.14.x will fail build, must first update the function (and this test project) to .net 8 or newer-->
+    <!-- Upgrading to 17.14.0 will fail build, must first update the function (and this test project) to .net 8 or newer-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
Reverts Altinn/altinn-events#741, as this seems to break one of the integration tests (validating subscriptions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions for Azure Key Vault dependencies.
  * Clarified version comment for a test package reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->