### PR TITLE
Add telemetryInitializer to set the cloud role name

### DIFF
--- a/src/Events.Functions/Program.cs
+++ b/src/Events.Functions/Program.cs
@@ -1,10 +1,12 @@
 ﻿using Altinn.Common.AccessTokenClient.Services;
+using Altinn.Platform.Events.Functions;
 using Altinn.Platform.Events.Functions.Clients;
 using Altinn.Platform.Events.Functions.Clients.Interfaces;
 using Altinn.Platform.Events.Functions.Configuration;
 using Altinn.Platform.Events.Functions.Services;
 using Altinn.Platform.Events.Functions.Services.Interfaces;
 
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +28,7 @@ builder.Services.AddSingleton<IAccessTokenGenerator, AccessTokenGenerator>();
 
 builder.Services.AddSingleton<ICertificateResolverService, CertificateResolverService>();
 builder.Services.AddSingleton<IKeyVaultService, KeyVaultService>();
+builder.Services.AddSingleton<ITelemetryInitializer, TelemetryInitializer>();
 builder.Services.AddHttpClient<IEventsClient, EventsClient>();
 builder.Services.AddHttpClient<IWebhookService, WebhookService>();
 


### PR DESCRIPTION
The cloud role name is set during startup to a fixed string.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #800 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced application telemetry to provide richer diagnostics and observability in production.
  * Improved event correlation and monitoring to help identify issues faster and reduce time to resolution.
  * Increases reliability and stability through better insight into runtime behavior.
  * No changes to user experience or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->