### PR TITLE
Add grants to new table partition for platform-events user

### DIFF
--- a/src/Events/Migration/v0.51/01-setup-grants.sql
+++ b/src/Events/Migration/v0.51/01-setup-grants.sql
@@ -1,0 +1,2 @@
+-- Grant permissions to platform_events role
+GRANT SELECT, INSERT, UPDATE, DELETE ON events.trace_log_y2026 TO platform_events;


### PR DESCRIPTION
New partitions must be handled like new tables, so the platform_events user must be granted the necessary privileges.

## Related Issue(s)
- #758 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database migration script to configure role-based permissions for event data management infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->