### PR TITLE
Fix failing init phase of subscriptions k6 test

### DIFF
--- a/test/k6/src/tests/app-events.js
+++ b/test/k6/src/tests/app-events.js
@@ -31,7 +31,7 @@ export const options = {
 
 export function setup() {
   var scopes = "altinn:serviceowner";
-  const app = __ENV.app.toLowerCase();
+  const app = (__ENV.app || '').toLowerCase();
   const org = "ttd";
   let partyId = __ENV.partyId;
 

--- a/test/k6/src/tests/subscriptions.js
+++ b/test/k6/src/tests/subscriptions.js
@@ -36,7 +36,7 @@ const scopes =
 const webhookEndpoint = __ENV.webhookEndpoint;
 
 const org = "ttd";
-const app = __ENV.app.toLowerCase();
+const app = (__ENV.app || '').toLowerCase();
 const runFullTestSet = __ENV.runFullTestSet
   ? __ENV.runFullTestSet.toLowerCase().includes("true")
   : false;


### PR DESCRIPTION
## Description
Add fallback value (empty string) for __ENV.app in the script, as this variable is undefined in the init phase of the k6 test. 

This should fix the currently use-case tests (https://github.com/Altinn/altinn-events/actions/runs/20062350487/job/57542156176)


## Related Issue(s)
- https://github.com/Altinn/team-core-private/issues/266
## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in test environments by adding null safety checks for configuration values, preventing runtime errors when optional environment variables are not provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->