### PR TITLE
Add validation of unit (org number) to avoid 500 responses

### DIFF
--- a/src/Events/Controllers/AppController.cs
+++ b/src/Events/Controllers/AppController.cs
@@ -243,7 +243,7 @@ namespace Altinn.Platform.Events.Controllers
                 return (false, "Only one of 'Party' or 'Unit' can be defined.");
             }
 
-            if (!string.IsNullOrEmpty(unit) && unit.Length != 9)
+            if (!string.IsNullOrEmpty(unit) && (unit.Length != 9 || !unit.All(char.IsDigit)))
             {
                 return (false, "Value of 'Unit' needs to be exactly 9 digits.");
             }

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
@@ -1081,6 +1081,35 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
             /// <summary>
             /// Scenario:
+            ///   Get events with unit query parameter having wrong format (not 9 digits)
+            /// Expected result:
+            ///   The result be a problem detail object
+            /// Success criteria:
+            ///   Result status is 400 bad request and the problem details specifying the unit format requirement.
+            /// </summary>
+            [Fact]
+            public async Task GetForParty_WrongFormatQueryParamUnitWithLetters_ReturnsBadRequest()
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/app/party?after=e31dbb11-2208-4dda-a549-92a0db8c7708&from=2020-01-01Z&size=5&unit=123456MVA";
+
+                HttpClient client = GetTestClient(new EventsServiceMock(1));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(1337));
+
+                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                string responseString = await response.Content.ReadAsStringAsync();
+                var actual = JsonSerializer.Deserialize<ProblemDetails>(responseString, _options);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                Assert.StartsWith("Value of 'Unit' needs to be exactly 9 digits.", actual.Detail);
+            }
+
+            /// <summary>
+            /// Scenario:
             ///   Get events with both partyId and person number defined as filter parameters
             /// Expected result:
             ///   The result be a problem detail object


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #866 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation tightened for Unit query parameter: when supplied, Unit must be exactly 9 digits. Requests with invalid Unit formats now return a clear 400 error indicating the required format.

* **Tests**
  * Added negative tests verifying invalid Unit formats (wrong length or non-digit characters) produce a 400 response with the expected error detail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->