### PR TITLE
Fix flaky k6 test for GET app/party

### DIFF
--- a/.github/workflows/use-case-PROD.yaml
+++ b/.github/workflows/use-case-PROD.yaml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '*/15 * * * *'
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
 
 jobs:
   use-case-test:


### PR DESCRIPTION
Adds an alternative for the "hacky" use of query parameter `after` (using a functionally invalid value of `1`) with `from`. The proposed value is representative for real user data on this operation.

Running the DB function `events.getappevents_v2` yields the same data result when using this `from` value, compared to `after=1`.
Using a valid value for `from` should hit the additional `time` index, hopefully giving a nice speed-up on the duration for DB processing

Adding the new test while keeping the old one around allows us to compare their performance to each other. If the new one proves to solve the performance issue, we can remove the old one.

Related issue: 408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated party events test to use a fixed timestamp instead of a relative offset for more consistent, reliable results; test descriptions and messages updated accordingly.
  * Clarified that pagination/next-link behavior is unchanged.

* **Chores**
  * CI workflow extended to run on pull-request events targeting main, enabling PR-based execution in addition to existing triggers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->