### PR TITLE
Reduce time frame for k6 test fetching app/party events

### DIFF
--- a/test/k6/src/tests/app-events.js
+++ b/test/k6/src/tests/app-events.js
@@ -97,8 +97,11 @@ function TC02_GetAppEventsForOrgFromNextUrl(data, nextUrl) {
 
 // 03 -  GET app events for party. Query parameters: partyId, from.
 function TC03_GetAppEventsForParty(data) {
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
   let response = appEventsApi.getEventsForParty(
-    { from: '2025-12-31T23:00:00Z', party: data.userPartyId },
+    { from: thirtyDaysAgo.toISOString(), party: data.userPartyId },
     data.userToken
   );
 


### PR DESCRIPTION
Removes the old test that uses only `party` and `after=1`. 
Although the alternative test using `from` hits the composite index on [subject_time](https://github.com/Altinn/altinn-events/blob/main/src/Events/Migration/v0.39/01-new-indexes.sql) rather than the subject index, we have made observations in DB queries that the result still needs narrowing down. Here we narrow form 2+ years to 1 month.

Ref. https://github.com/Altinn/team-core-private/issues/431


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Merged multiple app-event test variants into a single unified test to reduce duplication and simplify maintenance.
  * Test now queries events using a rolling 30-day window instead of a fixed timestamp.
  * Test orchestration updated so the consolidated test replaces the previous variants while preserving the overall test flow and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->