### PR TITLE
Narrow k6 GET app/party events test time frame 30 -> 7 days

### DIFF
--- a/test/k6/src/tests/app-events.js
+++ b/test/k6/src/tests/app-events.js
@@ -97,22 +97,22 @@ function TC02_GetAppEventsForOrgFromNextUrl(data, nextUrl) {
 
 // 03 -  GET app events for party. Query parameters: partyId, from.
 function TC03_GetAppEventsForParty(data) {
-  const thirtyDaysAgo = new Date();
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  const today = new Date();
+  const sevenDaysAgo = new Date(today.setDate(today.getDate() - 7));
 
   let response = appEventsApi.getEventsForParty(
-    { from: thirtyDaysAgo.toISOString(), party: data.userPartyId },
+    { from: sevenDaysAgo.toISOString(), party: data.userPartyId },
     data.userToken
   );
 
   let nextUrl = response.headers["Next"];
 
   let success = check(response, {
-    "03a - GET app events for party. Query parameters: partyId, from. Status is 200":
+    "03 - GET app events for party. Query parameters: partyId, from. Status is 200":
       (r) => r.status === 200,
-    "03a - GET app events for party. Query parameters: partyId, from. List contains minimum one element":
+    "03 - GET app events for party. Query parameters: partyId, from. List contains minimum one element":
       (r) => JSON.parse(r.body).length >= 1,
-    "03a - GET app events for party. Query parameters: partyId, from. Next url provided":
+    "03 - GET app events for party. Query parameters: partyId, from. Next url provided":
       nextUrl,
   });
 


### PR DESCRIPTION
Apparently, the test is still too slow: https://github.com/Altinn/altinn-events/actions/runs/21716600347/job/62634215696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated party events query to use a 7-day window instead of 30 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->