### PR TITLE
WorkloadIdentity: Remove usage of clientId from secrets

### DIFF
--- a/src/Events/Program.cs
+++ b/src/Events/Program.cs
@@ -57,10 +57,6 @@ using Yuniql.PostgreSql;
 
 ILogger logger;
 
-string vaultApplicationInsightsKey = "ApplicationInsights--InstrumentationKey";
-
-string applicationInsightsConnectionString = string.Empty;
-
 var builder = WebApplication.CreateBuilder(args);
 
 ConfigureWebHostCreationLogging();
@@ -110,40 +106,14 @@ async Task SetConfigurationProviders(ConfigurationManager config)
 
     config.AddEnvironmentVariables();
 
-    await ConnectToKeyVaultAndSetApplicationInsights(config);
+    var keyVaultUri = config.GetValue<string>("kvSetting:SecretUri");
+
+    if (!string.IsNullOrEmpty(keyVaultUri))
+    {
+        config.AddAzureKeyVault(new Uri(keyVaultUri), new DefaultAzureCredential());
+    }
 
     config.AddCommandLine(args);
-}
-
-async Task ConnectToKeyVaultAndSetApplicationInsights(ConfigurationManager config)
-{
-    KeyVaultSettings keyVaultSettings = new();
-    config.GetSection("kvSetting").Bind(keyVaultSettings);
-    if (!string.IsNullOrEmpty(keyVaultSettings.ClientId) &&
-        !string.IsNullOrEmpty(keyVaultSettings.TenantId) &&
-        !string.IsNullOrEmpty(keyVaultSettings.ClientSecret) &&
-        !string.IsNullOrEmpty(keyVaultSettings.SecretUri))
-    {
-        logger.LogInformation("Program // Configure key vault client // App");
-        Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", keyVaultSettings.ClientId);
-        Environment.SetEnvironmentVariable("AZURE_CLIENT_SECRET", keyVaultSettings.ClientSecret);
-        Environment.SetEnvironmentVariable("AZURE_TENANT_ID", keyVaultSettings.TenantId);
-        var azureCredentials = new DefaultAzureCredential();
-
-        config.AddAzureKeyVault(new Uri(keyVaultSettings.SecretUri), azureCredentials);
-
-        SecretClient client = new SecretClient(new Uri(keyVaultSettings.SecretUri), azureCredentials);
-
-        try
-        {
-            KeyVaultSecret keyVaultSecret = await client.GetSecretAsync(vaultApplicationInsightsKey);
-            applicationInsightsConnectionString = string.Format("InstrumentationKey={0}", keyVaultSecret.Value);
-        }
-        catch (Exception vaultException)
-        {
-            logger.LogError(vaultException, $"Unable to read application insights key.");
-        }
-    }
 }
 
 void ConfigureApplicationLogging(ILoggingBuilder logging)
@@ -186,10 +156,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
             tracing.AddProcessor(new RequestFilterProcessor(new HttpContextAccessor()));
         });
 
-    if (!string.IsNullOrEmpty(applicationInsightsConnectionString))
-    {
-        AddAzureMonitorTelemetryExporters(services, applicationInsightsConnectionString);
-    }
+    AddAzureMonitorTelemetryExporters(services, config);
 
     services.AddSingleton<TelemetryClient>();
 
@@ -365,8 +332,17 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     });
 }
 
-void AddAzureMonitorTelemetryExporters(IServiceCollection services, string applicationInsightsConnectionString)
+void AddAzureMonitorTelemetryExporters(IServiceCollection services, IConfiguration config)
 {
+    var instrumentationKey = config.GetValue<string>("ApplicationInsights:InstrumentationKey");
+
+    if (string.IsNullOrEmpty(instrumentationKey))
+    {
+        return;
+    }
+
+    var applicationInsightsConnectionString = string.Format("InstrumentationKey={0}", instrumentationKey);
+
     services.Configure<OpenTelemetryLoggerOptions>(logging => logging.AddAzureMonitorLogExporter(o =>
     {
         o.ConnectionString = applicationInsightsConnectionString;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- A related PR in helm chart also exists

## Related Issue(s)
- #https://github.com/Altinn/altinn-events/issues/859

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored Azure Monitor telemetry exporter configuration to transition from local secret retrieval to a configuration-driven instrumentation key setup.
  * Updated credential handling to leverage Azure Key Vault with DefaultAzureCredential for enhanced security and streamlined credential management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->