### PR TITLE
chore: Mend broken Docker scanning workflow

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -31,7 +31,7 @@ jobs:
         run: docker build . --tag altinn-events:${{github.sha}}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: 'altinn-events:${{ github.sha }}'
           format: 'table'

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -2,17 +2,22 @@ name: Events Scan
 
 on:
   schedule:
-  - cron: '0 8 * * 1,4'
+    - cron: '0 8 * * 1,4'
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'src/Events/**'
       - 'Dockerfile'
+      - '.trivyignore.yaml'
+      - '.github/workflows/container-scan.yml'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - 'src/Events/**'
       - 'Dockerfile'
+      - '.trivyignore.yaml'
+      - '.github/workflows/container-scan.yml'
+
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -22,11 +27,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Build the Docker image        
+      - name: Build the Docker image
         run: docker build . --tag altinn-events:${{github.sha}}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # v0.34.1
         with:
           image-ref: 'altinn-events:${{ github.sha }}'
           format: 'table'
@@ -34,6 +39,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          trivyignores: '.trivyignore.yaml'
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -43,3 +43,4 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
+          TRIVY_SHOW_SUPPRESSED: true

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,4 @@
+vulnerabilities:
+  - id: CVE-2026-28390 # libcrypto3/libssl3
+    statement: Not exploitable - application does not process attacker-controlled CMS data
+    expires: 2026-05-10 # revisit in 1 month, might have a patch by then

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,4 +1,4 @@
 vulnerabilities:
   - id: CVE-2026-28390 # libcrypto3/libssl3
     statement: Not exploitable - application does not process attacker-controlled CMS data
-    expires: 2026-05-10 # revisit in 1 month, might have a patch by then
+    expired_at: 2026-05-10 # revisit in 1 month, might have a patch by then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.200-alpine3.23@sha256:a0116e63beedf9197c3d491eb224aea9ae7d1692079eda9eebe2809f06d580e3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.201-alpine3.23@sha256:a65df8d9ad0661a1a785a4f26188b3a2826540d448df317ac69cfb6e801e1592 AS build
 
 COPY src/Events ./Events
 COPY src/DbTools ./DbTools
@@ -12,7 +12,7 @@ WORKDIR /Events
 RUN dotnet build ./Altinn.Platform.Events.csproj -c Release -o /app_output
 RUN dotnet publish ./Altinn.Platform.Events.csproj -c Release -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.5-alpine3.23@sha256:8c7671a6f0f984d0c102ee70d61e8010857de032b320561dea97cc5781aea5f8 AS final
 
 EXPOSE 5080
 WORKDIR /app


### PR DESCRIPTION
- Patching to latest dotnet Docker images, as these include a fix for the old `zlib `library vulnerability. 
- Adding a new `.trivyignore.yaml` file where we can keep temporary records of unexploitable vulnerabilities that unnecessarily break our scanning job
  - Includes the latest vulnerability ([CVE-2026-28390](https://nvd.nist.gov/vuln/detail/CVE-2026-28390)) 
- Relevant extensions of the trivy-action
  - Tell it to use the new ignore-file
  - Add a new env var for a flag that allows displaying suppressed vulnerabilities in the job output
- Adds a 'v' prefix to version tag for trivy-action
- Extend PR trigger / path filters for the container-scan workflow, so that the workflow is triggered in PR/push when edits are made to it or to the ignore file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker base images to latest patch versions for SDK and runtime.
  * Improved container scanning workflow: schedule formatting adjusted, trigger paths expanded to include workflow and vulnerability-ignore file, scanner action updated, and scans now respect the configured ignore rules.

* **Security**
  * Added a temporary ignore for CVE-2026-28390 marked "Not exploitable" with reassessment date 2026-05-10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->