### PR TITLE
Remove manipulation of cached list of subscriptions.

### DIFF
--- a/src/Events/Repository/ISubscriptionRepository.cs
+++ b/src/Events/Repository/ISubscriptionRepository.cs
@@ -51,7 +51,7 @@ public interface ISubscriptionRepository
     /// A cancellation token that can be used by other objects or threads to receive notice of cancellation.
     /// </param>
     /// <returns>A task representing the asynchronous operation with a list of subscriptions.</returns>
-    Task<List<Subscription>> GetSubscriptions(
+    Task<IReadOnlyList<Subscription>> GetSubscriptions(
         string resource, string subject, string eventType, CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/Events/Repository/SubscriptionRepository.cs
+++ b/src/Events/Repository/SubscriptionRepository.cs
@@ -86,7 +86,7 @@ public class SubscriptionRepository : ISubscriptionRepository
     }
 
     /// <inheritdoc/>
-    public async Task<List<Subscription>> GetSubscriptions(
+    public async Task<IReadOnlyList<Subscription>> GetSubscriptions(
         string resource, string subject, string eventType, CancellationToken cancellationToken)
     {
         List<Subscription> searchResult = [];
@@ -103,7 +103,7 @@ public class SubscriptionRepository : ISubscriptionRepository
             searchResult.Add(GetSubscription(reader));
         }
 
-        return searchResult;
+        return searchResult.AsReadOnly();
     }
 
     /// <inheritdoc/>

--- a/src/Events/Repository/SubscriptionRepositoryCachingDecorator.cs
+++ b/src/Events/Repository/SubscriptionRepositoryCachingDecorator.cs
@@ -38,12 +38,12 @@ namespace Altinn.Platform.Events.Repository
         }
 
         /// <inheritdoc/>
-        public async Task<List<Subscription>> GetSubscriptions(
+        public async Task<IReadOnlyList<Subscription>> GetSubscriptions(
             string resource, string subject, string eventType, CancellationToken cancellationToken)
         {
             string cacheKey = GetSubscriptionCacheKey(resource, subject, eventType);
 
-            if (!_memoryCache.TryGetValue(cacheKey, out List<Subscription> subscriptions))
+            if (!_memoryCache.TryGetValue(cacheKey, out IReadOnlyList<Subscription> subscriptions))
             {
                 subscriptions = 
                     await _decoratedService.GetSubscriptions(resource, subject, eventType, cancellationToken);

--- a/src/Events/Services/OutboundService.cs
+++ b/src/Events/Services/OutboundService.cs
@@ -78,11 +78,15 @@ public class OutboundService : IOutboundService
     /// <inheritdoc/>
     public async Task PostOutbound(CloudEvent cloudEvent, CancellationToken cancellationToken, bool useAzureServiceBus = false)
     {
-        List<Subscription> subscriptions = await _subscriptionRepository.GetSubscriptions(
+        List<Subscription> allSubscriptions = [];
+        
+        IReadOnlyList<Subscription> directSubscriptions = await _subscriptionRepository.GetSubscriptions(
              cloudEvent.GetResource(),
              cloudEvent.Subject,
              cloudEvent.Type,
              cancellationToken);
+
+        allSubscriptions.AddRange(directSubscriptions);
 
         string? alternativeSubject = cloudEvent["alternativesubject"]?.ToString();
         var (mainUnitLookupUrn, originalFormat) = GetSubjectLookupDetails(cloudEvent.Subject, alternativeSubject);
@@ -99,18 +103,18 @@ public class OutboundService : IOutboundService
 
                 if (mainUnitSubject != null)
                 {
-                    List<Subscription> mainUnitSubscriptions = await _subscriptionRepository.GetSubscriptions(
+                    IReadOnlyList<Subscription> mainUnitSubscriptions = await _subscriptionRepository.GetSubscriptions(
                         cloudEvent.GetResource(),
                         mainUnitSubject,
                         cloudEvent.Type,
                         cancellationToken);
 
-                    subscriptions.AddRange(mainUnitSubscriptions.Where(s => s.IncludeSubunits));
+                    allSubscriptions.AddRange(mainUnitSubscriptions.Where(s => s.IncludeSubunits));
                 }
             }
         }
 
-        await AuthorizeAndPush(cloudEvent, subscriptions, cancellationToken, useAzureServiceBus);
+        await AuthorizeAndPush(cloudEvent, allSubscriptions, cancellationToken, useAzureServiceBus);
     }
 
     private enum SubjectFormat

--- a/test/Altinn.Platform.Events.Tests/Mocks/SubscriptionRepositoryMock.cs
+++ b/test/Altinn.Platform.Events.Tests/Mocks/SubscriptionRepositoryMock.cs
@@ -73,7 +73,7 @@ namespace Altinn.Platform.Events.Tests.Mocks
             return Task.CompletedTask;
         }
 
-        public Task<List<Subscription>> GetSubscriptions(string resource, string subject, string type, CancellationToken ct)
+        public Task<IReadOnlyList<Subscription>> GetSubscriptions(string resource, string subject, string type, CancellationToken ct)
         {
             List<Subscription> subscriptions = new();
 
@@ -105,7 +105,7 @@ namespace Altinn.Platform.Events.Tests.Mocks
                     })
                 .ToList();
 
-            return Task.FromResult(subscriptions);
+            return Task.FromResult((IReadOnlyList<Subscription>)subscriptions);
         }
 
         private static string GetSubscriptionPath()

--- a/test/Altinn.Platform.Events.Tests/Mocks/SubscriptionRepositoryMock.cs
+++ b/test/Altinn.Platform.Events.Tests/Mocks/SubscriptionRepositoryMock.cs
@@ -105,7 +105,7 @@ namespace Altinn.Platform.Events.Tests.Mocks
                     })
                 .ToList();
 
-            return Task.FromResult((IReadOnlyList<Subscription>)subscriptions);
+            return Task.FromResult((IReadOnlyList<Subscription>)subscriptions.AsReadOnly());
         }
 
         private static string GetSubscriptionPath()


### PR DESCRIPTION
## Description
Fixing bug in the new IncludeSubunits feature of subscriptions. Main unit subscriptions were repeatedly added to the cached list of subscriptions for the event. The result were that the same event were sent to the subscriber multiple times.

## Related Issue(s)
- #975 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced subscription handling by making internal collections immutable to prevent unintended modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->