### PR TITLE
Replace jsrsasign with k6 built-in crypto.subtle API

### DIFF
--- a/test/k6/src/api/maskinporten.js
+++ b/test/k6/src/api/maskinporten.js
@@ -54,6 +54,14 @@ function base64urlEncode(obj) {
   return encoding.b64encode(JSON.stringify(obj), "rawurl");
 }
 
+function stringToBytes(str) {
+  const buf = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i++) {
+    buf[i] = str.charCodeAt(i);
+  }
+  return buf;
+}
+
 async function createJwtGrant(scopes) {
   const header = {
     alg: "RS256",
@@ -83,7 +91,7 @@ async function createJwtGrant(scopes) {
   );
 
   const signingInput = base64urlEncode(header) + "." + base64urlEncode(payload);
-  const data = new TextEncoder().encode(signingInput);
+  const data = stringToBytes(signingInput);
   const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", cryptoKey, data);
 
   return signingInput + "." + encoding.b64encode(new Uint8Array(signature), "rawurl");

--- a/test/k6/src/api/maskinporten.js
+++ b/test/k6/src/api/maskinporten.js
@@ -12,6 +12,8 @@ const encodedJwk = __ENV.encodedJwk;
 const mpClientId = __ENV.mpClientId;
 const mpKid = __ENV.mpKid;
 
+let memoizedSigningKeyPromise;
+
 /**
  * Authenticates with Maskinporten and returns an access token.
  * @param {string} scopes - Space-separated list of scopes to request.
@@ -54,6 +56,33 @@ export async function generateAccessToken(scopes) {
   const accessToken = JSON.parse(res.body)['access_token'];
   return accessToken;
 }
+
+/**
+ * Imports the RSA signing key from the base64-encoded JWK environment variable.
+ * @returns {Promise<CryptoKey>} The imported signing key.
+ */
+async function importSigningKey() {
+  const jwk = JSON.parse(encoding.b64decode(encodedJwk, "std", "s"));
+  return crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+}
+
+/**
+ * Returns the memoized signing key, importing it on first call. Caching the promise (rather than the resolved value) allows concurrent calls to share the same in-flight import rather than triggering duplicates.
+ * @returns {Promise<CryptoKey>} The signing key.
+ */
+function getSigningKey() {
+  if (!memoizedSigningKeyPromise) {
+    memoizedSigningKeyPromise = importSigningKey();
+  }
+  return memoizedSigningKeyPromise;
+}
+
 
 /**
  * Base64url-encodes a JSON-serializable object without padding.
@@ -100,15 +129,7 @@ async function createJwtGrant(scopes) {
     jti: uuidv4(),
   };
 
-  const jwk = JSON.parse(encoding.b64decode(encodedJwk, "std", "s"));
-
-  const cryptoKey = await crypto.subtle.importKey(
-    "jwk",
-    jwk,
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
+  const cryptoKey = await getSigningKey();
 
   const signingInput = base64urlEncode(header) + "." + base64urlEncode(payload);
   const data = stringToBytes(signingInput);

--- a/test/k6/src/api/maskinporten.js
+++ b/test/k6/src/api/maskinporten.js
@@ -5,7 +5,7 @@ import http from "k6/http";
 import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import KJUR from "https://unpkg.com/jsrsasign@10.8.6/lib/jsrsasign.js";
 
-import { buildHeaderWithContentType}  from "../apiHelpers.js";
+import { buildHeaderWithContentType } from "../apiHelpers.js";
 import * as config from "../config.js";
 import { stopIterationOnFail, addErrorCount } from "../errorhandler.js";
 
@@ -14,15 +14,15 @@ const mpClientId = __ENV.mpClientId;
 const mpKid = __ENV.mpKid;
 
 export function generateAccessToken(scopes) {
-  if(!encodedJwk){
+  if (!encodedJwk) {
     stopIterationOnFail("Required environment variable Encoded JWK (encodedJWK) was not provided", false);
   }
 
-  if(!mpClientId){
+  if (!mpClientId) {
     stopIterationOnFail("Required environment variable maskinporten client id (mpClientId) was not provided", false);
   }
 
-  if(!mpKid){
+  if (!mpKid) {
     stopIterationOnFail("Required environment variable maskinporten kid (mpKid) was not provided", false);
   }
 
@@ -69,11 +69,13 @@ function createJwtGrant(scopes) {
     jti: uuidv4(),
   };
 
+  const jwk = JSON.parse(encoding.b64decode(encodedJwk, "std", "s"));
+
   const signedJWT = KJUR.jws.JWS.sign(
     "RS256",
     header,
     payload,
-    JSON.parse(encoding.b64decode(encodedJwk, "std", "s"))
+    jwk
   );
 
   return signedJWT;

--- a/test/k6/src/api/maskinporten.js
+++ b/test/k6/src/api/maskinporten.js
@@ -17,7 +17,7 @@ let memoizedSigningKeyPromise;
 /**
  * Authenticates with Maskinporten and returns an access token.
  * @param {string} scopes - Space-separated list of scopes to request.
- * @returns {string} The Maskinporten access token.
+ * @returns {Promise<string>} The Maskinporten access token.
  */
 export async function generateAccessToken(scopes) {
   if (!encodedJwk) {

--- a/test/k6/src/api/maskinporten.js
+++ b/test/k6/src/api/maskinporten.js
@@ -12,6 +12,11 @@ const encodedJwk = __ENV.encodedJwk;
 const mpClientId = __ENV.mpClientId;
 const mpKid = __ENV.mpKid;
 
+/**
+ * Authenticates with Maskinporten and returns an access token.
+ * @param {string} scopes - Space-separated list of scopes to request.
+ * @returns {string} The Maskinporten access token.
+ */
 export async function generateAccessToken(scopes) {
   if (!encodedJwk) {
     stopIterationOnFail("Required environment variable Encoded JWK (encodedJWK) was not provided", false);
@@ -50,10 +55,20 @@ export async function generateAccessToken(scopes) {
   return accessToken;
 }
 
+/**
+ * Base64url-encodes a JSON-serializable object without padding.
+ * @param {object} obj - The object to encode.
+ * @returns {string} The base64url-encoded string.
+ */
 function base64urlEncode(obj) {
   return encoding.b64encode(JSON.stringify(obj), "rawurl");
 }
 
+/**
+ * Converts an ASCII string to a Uint8Array.
+ * @param {string} str - The input string (ASCII only).
+ * @returns {Uint8Array} The byte representation.
+ */
 function stringToBytes(str) {
   const buf = new Uint8Array(str.length);
   for (let i = 0; i < str.length; i++) {
@@ -62,6 +77,11 @@ function stringToBytes(str) {
   return buf;
 }
 
+/**
+ * Creates a signed JWT grant for the Maskinporten token request.
+ * @param {string} scopes - Space-separated list of scopes to include in the grant.
+ * @returns {Promise<string>} The signed JWT string.
+ */
 async function createJwtGrant(scopes) {
   const header = {
     alg: "RS256",

--- a/test/k6/src/api/maskinporten.js
+++ b/test/k6/src/api/maskinporten.js
@@ -3,7 +3,6 @@ import encoding from "k6/encoding";
 import http from "k6/http";
 
 import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
-import KJUR from "https://unpkg.com/jsrsasign@10.8.6/lib/jsrsasign.js";
 
 import { buildHeaderWithContentType } from "../apiHelpers.js";
 import * as config from "../config.js";
@@ -13,7 +12,7 @@ const encodedJwk = __ENV.encodedJwk;
 const mpClientId = __ENV.mpClientId;
 const mpKid = __ENV.mpKid;
 
-export function generateAccessToken(scopes) {
+export async function generateAccessToken(scopes) {
   if (!encodedJwk) {
     stopIterationOnFail("Required environment variable Encoded JWK (encodedJWK) was not provided", false);
   }
@@ -26,7 +25,7 @@ export function generateAccessToken(scopes) {
     stopIterationOnFail("Required environment variable maskinporten kid (mpKid) was not provided", false);
   }
 
-  const grant = createJwtGrant(scopes);
+  const grant = await createJwtGrant(scopes);
 
   const body = {
     alg: "RS256",
@@ -51,7 +50,11 @@ export function generateAccessToken(scopes) {
   return accessToken;
 }
 
-function createJwtGrant(scopes) {
+function base64urlEncode(obj) {
+  return encoding.b64encode(JSON.stringify(obj), "rawurl");
+}
+
+async function createJwtGrant(scopes) {
   const header = {
     alg: "RS256",
     typ: "JWT",
@@ -71,12 +74,17 @@ function createJwtGrant(scopes) {
 
   const jwk = JSON.parse(encoding.b64decode(encodedJwk, "std", "s"));
 
-  const signedJWT = KJUR.jws.JWS.sign(
-    "RS256",
-    header,
-    payload,
-    jwk
+  const cryptoKey = await crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
   );
 
-  return signedJWT;
+  const signingInput = base64urlEncode(header) + "." + base64urlEncode(payload);
+  const data = new TextEncoder().encode(signingInput);
+  const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", cryptoKey, data);
+
+  return signingInput + "." + encoding.b64encode(new Uint8Array(signature), "rawurl");
 }

--- a/test/k6/src/setup.js
+++ b/test/k6/src/setup.js
@@ -10,9 +10,9 @@ const environment = (__ENV.altinn_env || '').toLowerCase(); // Fallback value fo
  * If org is not provided TTD will be used.
  * @returns altinn token with the provided scopes for an org
  */
-export function getAltinnTokenForOrg(scopes, org = "ttd", orgNo = "991825827") {
+export async function getAltinnTokenForOrg(scopes, org = "ttd", orgNo = "991825827") {
   if ((environment == "prod" || environment == "tt02") && org == "ttd") {
-    let accessToken = maskinporten.generateAccessToken(scopes);
+    let accessToken = await maskinporten.generateAccessToken(scopes);
     return authentication.exchangeToAltinnToken(accessToken, true);
   }
 

--- a/test/k6/src/tests/app-events.js
+++ b/test/k6/src/tests/app-events.js
@@ -28,7 +28,7 @@ export const options = {
   },
 };
 
-export function setup() {
+export async function setup() {
   let scopes = "altinn:serviceowner";
   const app = __ENV.app.toLowerCase();
   const org = "ttd";
@@ -44,7 +44,7 @@ export function setup() {
     partyId = setupToken.getPartyIdFromTokenClaim(userToken);
   }
 
-  let orgToken = setupToken.getAltinnTokenForOrg(scopes, org);
+  let orgToken = await setupToken.getAltinnTokenForOrg(scopes, org);
 
   let data = {
     runFullTestSet: runFullTestSet,

--- a/test/k6/src/tests/events/get.js
+++ b/test/k6/src/tests/events/get.js
@@ -26,8 +26,8 @@ export const options = {
     },
 };
 
-export function setup() {
-    let token = setupToken.getAltinnTokenForOrg(scopes);
+export async function setup() {
+    let token = await setupToken.getAltinnTokenForOrg(scopes);
 
     let cloudEvent = eventJson;
     cloudEvent.id = uuidv4();

--- a/test/k6/src/tests/events/post.js
+++ b/test/k6/src/tests/events/post.js
@@ -26,8 +26,8 @@ export const options = {
     },
 };
 
-export function setup() {
-    const token = setupToken.getAltinnTokenForOrg(scopes);
+export async function setup() {
+    const token = await setupToken.getAltinnTokenForOrg(scopes);
 
     const runFullTestSet = __ENV.runFullTestSet
         ? __ENV.runFullTestSet.toLowerCase().includes("true")
@@ -128,12 +128,12 @@ function TC04_PostCloudEventWithoutBearerToken() {
 }
 
 // 05 - POST cloud event without required scope
-function TC05_PostCloudEventWithoutRequiredScopes() {
+async function TC05_PostCloudEventWithoutRequiredScopes() {
     let response, success, cloudEvent;
 
     cloudEvent = createCloudEvent();
 
-    let incorrectScopeToken = setupToken.getAltinnTokenForOrg('altinn:serviceowner');
+    let incorrectScopeToken = await setupToken.getAltinnTokenForOrg('altinn:serviceowner');
 
     response = eventsApi.postCloudEvent(
         JSON.stringify(cloudEvent),
@@ -155,7 +155,7 @@ function TC05_PostCloudEventWithoutRequiredScopes() {
  * 04 - POST cloud event without bearer token
  * 05 - POST cloud event without required scope
  */
-export default function runTests(data) {
+export default async function runTests(data) {
     try {
         if (data.runFullTestSet) {
             TC01_POstValidCloudEventWithAllParameters(data);

--- a/test/k6/src/tests/events/post.js
+++ b/test/k6/src/tests/events/post.js
@@ -166,7 +166,7 @@ export default async function runTests(data) {
 
             TC04_PostCloudEventWithoutBearerToken();
 
-            TC05_PostCloudEventWithoutRequiredScopes();
+            await TC05_PostCloudEventWithoutRequiredScopes();
         } else {
             // Limited test set for use case tests
 

--- a/test/k6/src/tests/performance/fixed-rate.js
+++ b/test/k6/src/tests/performance/fixed-rate.js
@@ -45,8 +45,8 @@ import {
 
 const eventType = `performancetest.fixed-rate.${runId}`;
 const targetRps = Number.parseInt(__ENV.targetRps || "20", 10);
-const duration  = __ENV.duration || "2m";
-const maxVus    = Number.parseInt(__ENV.maxVus || "50", 10);
+const duration = __ENV.duration || "2m";
+const maxVus = Number.parseInt(__ENV.maxVus || "50", 10);
 
 // Pre-allocate enough VUs to sustain targetRps assuming up to ~2s per request.
 // k6 will spin up more (up to maxVus) if needed mid-test.
@@ -56,24 +56,24 @@ warnIfUntagged();
 
 export const options = {
     thresholds: {
-        errors:         ["count<1"],
-        http_req_duration:  ["p(95)<5000"],
+        errors: ["count<1"],
+        http_req_duration: ["p(95)<5000"],
         dropped_iterations: ["count<1"],
     },
     scenarios: {
         fixed_rate: {
-            executor:        "constant-arrival-rate",
-            rate:            targetRps,
-            timeUnit:        "1s",
-            duration:        duration,
+            executor: "constant-arrival-rate",
+            rate: targetRps,
+            timeUnit: "1s",
+            duration: duration,
             preAllocatedVUs: preAllocatedVUs,
-            maxVUs:          maxVus,
+            maxVUs: maxVus,
         },
     },
 };
 
-export function setup() {
-    return performanceSetup(`Target rate: ${targetRps} events/s for ${duration} (preAllocated: ${preAllocatedVUs}, max: ${maxVus} VUs)`);
+export async function setup() {
+    return await performanceSetup(`Target rate: ${targetRps} events/s for ${duration} (preAllocated: ${preAllocatedVUs}, max: ${maxVus} VUs)`);
 }
 
 export default function runTests(data) {
@@ -87,9 +87,9 @@ export function teardown(data) {
 export function handleSummary(data) {
     const { durationSec } = getTimeWindow(data);
     const { successCount, errorCount, p95Ms } = getBaseMetrics(data);
-    const droppedCount  = data.metrics["dropped_iterations"]?.values?.count ?? 0;
-    const effectiveRps  = durationSec > 0 ? (successCount / durationSec).toFixed(1) : "N/A";
-    const targetMet     = droppedCount === 0 ? "YES" : `NO — ${droppedCount} iterations dropped`;
+    const droppedCount = data.metrics["dropped_iterations"]?.values?.count ?? 0;
+    const effectiveRps = durationSec > 0 ? (successCount / durationSec).toFixed(1) : "N/A";
+    const targetMet = droppedCount === 0 ? "YES" : `NO — ${droppedCount} iterations dropped`;
 
     return buildSummary("Fixed-Rate Throughput Test — Summary                 ║", [
         "  k6 results:",

--- a/test/k6/src/tests/performance/fixed-total.js
+++ b/test/k6/src/tests/performance/fixed-total.js
@@ -28,9 +28,9 @@ import {
     warnIfUntagged, getTimeWindow, getBaseMetrics, buildSummary,
 } from "./helpers.js";
 
-const eventType   = `performancetest.fixed-total.${runId}`;
+const eventType = `performancetest.fixed-total.${runId}`;
 const totalEvents = Number.parseInt(__ENV.totalEvents || "500", 10);
-const vus         = Number.parseInt(__ENV.vus || "10", 10);
+const vus = Number.parseInt(__ENV.vus || "10", 10);
 
 warnIfUntagged();
 
@@ -49,8 +49,8 @@ export const options = {
     },
 };
 
-export function setup() {
-    return performanceSetup(`Will post ${totalEvents} events across ${vus} VUs`);
+export async function setup() {
+    return await performanceSetup(`Will post ${totalEvents} events across ${vus} VUs`);
 }
 
 export default function runTests(data) {

--- a/test/k6/src/tests/performance/helpers.js
+++ b/test/k6/src/tests/performance/helpers.js
@@ -16,8 +16,8 @@ export function warnIfUntagged() {
     }
 }
 
-export function performanceSetup(setupLogLine) {
-    const token = setupToken.getAltinnTokenForOrg(scopes);
+export async function performanceSetup(setupLogLine) {
+    const token = await setupToken.getAltinnTokenForOrg(scopes);
 
     const subscription = {
         endPoint: config.platformEvents.webhookReceiver,
@@ -79,12 +79,12 @@ export function performanceTeardown(data) {
 }
 
 export function getTimeWindow(data) {
-    const testEndTime    = new Date();
+    const testEndTime = new Date();
     const testDurationMs = data.state.testRunDurationMs;
-    const testStartTime  = new Date(testEndTime.getTime() - testDurationMs);
+    const testStartTime = new Date(testEndTime.getTime() - testDurationMs);
 
     const offsetMinutes = Number.parseInt(__ENV.queryOffsetMinutes || "15", 10);
-    const queryEndTime  = new Date(testEndTime.getTime() + offsetMinutes * 60 * 1000);
+    const queryEndTime = new Date(testEndTime.getTime() + offsetMinutes * 60 * 1000);
 
     const durationSec = testDurationMs / 1000;
 
@@ -96,8 +96,8 @@ export function getTimeWindow(data) {
 
 export function getBaseMetrics(data) {
     const eventsPosted = data.metrics["iterations"]?.values?.count ?? 0;
-    const errorCount   = data.metrics["errors"]?.values?.count ?? 0;
-    const p95Ms        = data.metrics["http_req_duration"]?.values?.["p(95)"] ?? 0;
+    const errorCount = data.metrics["errors"]?.values?.count ?? 0;
+    const p95Ms = data.metrics["http_req_duration"]?.values?.["p(95)"] ?? 0;
     const successCount = Math.max(eventsPosted - errorCount, 0);
 
     return { eventsPosted, errorCount, p95Ms, successCount };

--- a/test/k6/src/tests/subscriptions.js
+++ b/test/k6/src/tests/subscriptions.js
@@ -50,9 +50,9 @@ export const options = {
   },
 };
 
-export function setup() {
-  let orgToken = setupToken.getAltinnTokenForOrg(scopes);
-  let incorrectScopeToken = setupToken.getAltinnTokenForOrg(
+export async function setup() {
+  let orgToken = await setupToken.getAltinnTokenForOrg(scopes);
+  let incorrectScopeToken = await setupToken.getAltinnTokenForOrg(
     "altinn:serviceowner"
   );
 


### PR DESCRIPTION
Tested with a [run of Regression test - TT02](https://github.com/Altinn/altinn-events/actions/runs/25438402181) against this branch

## Related Issue(s)
- https://github.com/Altinn/team-core-private/issues/476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to fully adopt async token flows; test setup hooks now await token acquisition for consistent execution.
  * Converted test runners and cases to async to improve reliability in load and functional scenarios.
  * Modernized token generation used by tests (improved signing/compatibility and robustness).

* **Chores**
  * Improved formatting and consistency in test configuration declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->