### PR TITLE
Remove invalid attribute "pinDigests" from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,8 +29,7 @@
       "matchStrings": [
         "\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\""
       ],
-      "datasourceTemplate": "docker",
-      "pinDigests": true
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
Renovate hasn't created any patch PRs to our repo since Feb 26th

<img width="1404" height="480" alt="bilde" src="https://github.com/user-attachments/assets/6b59c4f8-1886-4bb2-b2dc-b2b0d29cd912" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container image dependency management configuration to disable digest pinning, allowing more flexible handling of container image updates while maintaining Docker datasource integration for automated dependency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->