### PR TITLE
Pass SONAR_TOKEN to dotnet-sonarscanner via existing env var

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -1,9 +1,9 @@
 name: Code test and analysis
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - 'src/**'
+      - 'src/**'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -24,7 +24,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-            dotnet-version: 10.0.x
+          dotnet-version: 10.0.x
       - name: Set up JDK 11
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -32,16 +32,16 @@ jobs:
           java-version: 17
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install SonarCloud scanners
         run: |
           dotnet tool install --global dotnet-sonarscanner
       - name: Build & Test
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet-sonarscanner begin /k:"Altinn_altinn-events" /o:"altinn" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.cpd.exclusions="**/Swagger/*Filter.cs,**/Migration/**/*.sql" /d:sonar.coverage.exclusions="**/Migration/"
+          dotnet-sonarscanner begin /k:"Altinn_altinn-events" /o:"altinn" /d:sonar.login="$SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vstest.reportsPaths="**/*.trx" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" /d:sonar.cpd.exclusions="**/Swagger/*Filter.cs,**/Migration/**/*.sql" /d:sonar.coverage.exclusions="**/Migration/"
 
           dotnet build Altinn.Platform.Events.sln -v q
           dotnet test Altinn.Platform.Events.sln \
@@ -54,10 +54,10 @@ jobs:
       - name: Complete sonar analysis
         if: always()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
We have an existing and unused env var for SONAR_TOKEN in the Sonar script steps.
We should either use the env var or remove it and stick to the inline `${{ secrets.SONAR_TOKEN }}`.

For secrets specifically, GitHub masks the value in logs regardless of whether you use an env var or inline ${{ secrets.* }}, so the practical security difference is negligible either way.

I have chosen using the env var instead of inline ${{ }} as this is the general recommendation from GitHub in how to handle values that could be user-controlled (e.g. PR titles, issue bodies). For secrets, that risk doesn't apply since secrets aren't attacker-controlled. 
Consistently using env vars for secrets — even when there's no practical difference — reinforces the habit that matters when you do have user-controlled input. Consistency also makes code easier to review, since a reviewer doesn't have to reason about whether a particular inline ${{ }} is safe or not.

GitHub doc ref: https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and analysis workflow configuration to optimize environment variable handling and trigger conditions.

---

**Note:** This release contains internal infrastructure updates with no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-events/pull/991)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->