### PR TITLE
Use xUnit.v3. Fix warnings.

### DIFF
--- a/test/Altinn.Platform.Events.Functions.Tests/Altinn.Platform.Events.Functions.Tests.csproj
+++ b/test/Altinn.Platform.Events.Functions.Tests/Altinn.Platform.Events.Functions.Tests.csproj
@@ -1,46 +1,46 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
+		<PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)'=='Debug'">
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\stylecop.json">
-      <Link>stylecop.json</Link>
-    </AdditionalFiles>
-  </ItemGroup>
+	<ItemGroup Condition="'$(Configuration)'=='Debug'">
+		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<AdditionalFiles Include="..\..\stylecop.json">
+			<Link>stylecop.json</Link>
+		</AdditionalFiles>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Events.Common\Altinn.Platform.Events.Common.csproj" />
-    <ProjectReference Include="..\..\src\Events.Functions\Altinn.Platform.Events.Functions.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Events.Common\Altinn.Platform.Events.Common.csproj" />
+		<ProjectReference Include="..\..\src\Events.Functions\Altinn.Platform.Events.Functions.csproj" />
+	</ItemGroup>
 
-  <PropertyGroup>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);1591</NoWarn>
-  </PropertyGroup>
-  
+	<PropertyGroup>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
+	</PropertyGroup>
+
 </Project>

--- a/test/Altinn.Platform.Events.Functions.Tests/IntegrationTests/RequiresAzuriteFactAttribute.cs
+++ b/test/Altinn.Platform.Events.Functions.Tests/IntegrationTests/RequiresAzuriteFactAttribute.cs
@@ -1,3 +1,7 @@
+#nullable enable
+
+using System.Runtime.CompilerServices;
+
 using Xunit;
 
 namespace Altinn.Platform.Events.Functions.Tests.IntegrationTests;
@@ -11,7 +15,9 @@ namespace Altinn.Platform.Events.Functions.Tests.IntegrationTests;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public sealed class RequiresAzuriteFactAttribute : FactAttribute
 {
-    public RequiresAzuriteFactAttribute()
+    public RequiresAzuriteFactAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1) : base(sourceFilePath, sourceLineNumber)
     {
         if (!AzuriteTestsEnabled())
         {

--- a/test/Altinn.Platform.Events.IntegrationTests/Altinn.Platform.Events.IntegrationTests.csproj
+++ b/test/Altinn.Platform.Events.IntegrationTests/Altinn.Platform.Events.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Altinn.Platform.Events.IntegrationTests/Infrastructure/IntegrationTestContainersFixture.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/Infrastructure/IntegrationTestContainersFixture.cs
@@ -58,7 +58,7 @@ public class IntegrationTestContainersFixture : IAsyncLifetime
     /// <summary>
     /// Initializes the fixture by starting PostgreSQL, MSSQL, and Azure Service Bus Emulator containers.
     /// </summary>
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         try
         {
@@ -149,7 +149,7 @@ public class IntegrationTestContainersFixture : IAsyncLifetime
     /// <summary>
     /// Disposes the fixture by stopping and removing all containers.
     /// </summary>
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         static async Task SafeDisposeContainerAsync(IContainer? container)
         {

--- a/test/Altinn.Platform.Events.IntegrationTests/Infrastructure/IntegrationTestContainersFixture.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/Infrastructure/IntegrationTestContainersFixture.cs
@@ -20,7 +20,7 @@ namespace Altinn.Platform.Events.IntegrationTests.Infrastructure;
 /// This acts like a docker-compose setup, starting all infrastructure containers together.
 /// The fixture is shared across all tests in the collection to avoid starting/stopping containers repeatedly.
 /// </summary>
-public class IntegrationTestContainersFixture : IAsyncLifetime
+public sealed class IntegrationTestContainersFixture : IAsyncLifetime
 {
     private const string _mssqlSaPassword = "YourStrong!Passw0rd";
     private INetwork? _network;

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingControllers/EndToEndEventFlowTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingControllers/EndToEndEventFlowTests.cs
@@ -80,7 +80,8 @@ public class EndToEndEventFlowTests(IntegrationTestContainersFixture fixture)
 
             var createResponse = await subscribeClient.PostAsync(
                 "/events/api/v1/subscriptions",
-                new StringContent(subscriptionRequest.Serialize(), Encoding.UTF8, "application/json"));
+                new StringContent(subscriptionRequest.Serialize(), Encoding.UTF8, "application/json"),
+                TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
 
             // Step 2: Wait for subscription validation webhook
@@ -88,7 +89,8 @@ public class EndToEndEventFlowTests(IntegrationTestContainersFixture fixture)
                 () => Task.FromResult(webhookCalls.Any(c =>
                     c.CloudEvent.Type == "platform.events.validatesubscription")),
                 maxAttempts: 30,
-                delayMs: 500);
+                delayMs: 500,
+                TestContext.Current.CancellationToken);
             Assert.True(validationReceived, "Subscription validation webhook should be received");
 
             // Step 3: Post event via HTTP
@@ -100,7 +102,8 @@ public class EndToEndEventFlowTests(IntegrationTestContainersFixture fixture)
                 {
                     Content = new StringContent(
                         cloudEvent.Serialize(), Encoding.UTF8, "application/cloudevents+json")
-                });
+                },
+                TestContext.Current.CancellationToken);
             Assert.Equal(HttpStatusCode.OK, postResponse.StatusCode);
 
             // Step 4: Wait for event delivery to webhook
@@ -108,7 +111,8 @@ public class EndToEndEventFlowTests(IntegrationTestContainersFixture fixture)
                 () => Task.FromResult(webhookCalls.Any(c =>
                     c.CloudEvent.Type == "app.instance.created")),
                 maxAttempts: 30,
-                delayMs: 500);
+                delayMs: 500,
+                TestContext.Current.CancellationToken);
             Assert.True(eventDelivered, "Event should be delivered to webhook after processing through all queues");
 
             // Step 5: Verify delivered event content

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingControllers/EndToEndEventFlowTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingControllers/EndToEndEventFlowTests.cs
@@ -90,7 +90,7 @@ public class EndToEndEventFlowTests(IntegrationTestContainersFixture fixture)
                     c.CloudEvent.Type == "platform.events.validatesubscription")),
                 maxAttempts: 30,
                 delayMs: 500,
-                TestContext.Current.CancellationToken);
+                cancellationToken: TestContext.Current.CancellationToken);
             Assert.True(validationReceived, "Subscription validation webhook should be received");
 
             // Step 3: Post event via HTTP
@@ -112,7 +112,7 @@ public class EndToEndEventFlowTests(IntegrationTestContainersFixture fixture)
                     c.CloudEvent.Type == "app.instance.created")),
                 maxAttempts: 30,
                 delayMs: 500,
-                TestContext.Current.CancellationToken);
+                cancellationToken: TestContext.Current.CancellationToken);
             Assert.True(eventDelivered, "Event should be delivered to webhook after processing through all queues");
 
             // Step 5: Verify delivered event content

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/InboundQueueRetryTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/InboundQueueRetryTests.cs
@@ -74,7 +74,7 @@ public class InboundQueueRetryTests(IntegrationTestContainersFixture fixture)
                 () => Task.FromResult(!webhookCalls.IsEmpty),
                 maxAttempts: 30,
                 delayMs: 500,
-                TestContext.Current.CancellationToken);
+                cancellationToken: TestContext.Current.CancellationToken);
             Assert.True(delivered, "Event should be delivered to webhook via outbound queue");
 
             // Assert - Verify delivered event matches

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/InboundQueueRetryTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/InboundQueueRetryTests.cs
@@ -73,7 +73,8 @@ public class InboundQueueRetryTests(IntegrationTestContainersFixture fixture)
             var delivered = await WaitForUtils.WaitForAsync(
                 () => Task.FromResult(!webhookCalls.IsEmpty),
                 maxAttempts: 30,
-                delayMs: 500);
+                delayMs: 500,
+                TestContext.Current.CancellationToken);
             Assert.True(delivered, "Event should be delivered to webhook via outbound queue");
 
             // Assert - Verify delivered event matches

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/OutboundQueueRetryTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/OutboundQueueRetryTests.cs
@@ -55,7 +55,7 @@ public class OutboundQueueRetryTests(IntegrationTestContainersFixture fixture)
                 () => Task.FromResult(!webhookCalls.IsEmpty),
                 maxAttempts: 30,
                 delayMs: 500,
-                TestContext.Current.CancellationToken);
+                cancellationToken: TestContext.Current.CancellationToken);
             Assert.True(delivered, "Event should be delivered to webhook");
 
             // Assert - Verify delivered event matches

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/OutboundQueueRetryTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/OutboundQueueRetryTests.cs
@@ -54,7 +54,8 @@ public class OutboundQueueRetryTests(IntegrationTestContainersFixture fixture)
             var delivered = await WaitForUtils.WaitForAsync(
                 () => Task.FromResult(!webhookCalls.IsEmpty),
                 maxAttempts: 30,
-                delayMs: 500);
+                delayMs: 500,
+                TestContext.Current.CancellationToken);
             Assert.True(delivered, "Event should be delivered to webhook");
 
             // Assert - Verify delivered event matches

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/ValidationQueueRetryTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/ValidationQueueRetryTests.cs
@@ -55,7 +55,8 @@ public class ValidationQueueRetryTests(IntegrationTestContainersFixture fixture)
                     return sub?.Validated == true;
                 },
                 maxAttempts: 30,
-                delayMs: 500);
+                delayMs: 500,
+                TestContext.Current.CancellationToken);
             Assert.True(validated, "Subscription should be validated after successful webhook delivery");
 
             // Assert - Validation queue should be empty

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/ValidationQueueRetryTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/ValidationQueueRetryTests.cs
@@ -56,7 +56,7 @@ public class ValidationQueueRetryTests(IntegrationTestContainersFixture fixture)
                 },
                 maxAttempts: 30,
                 delayMs: 500,
-                TestContext.Current.CancellationToken);
+                cancellationToken: TestContext.Current.CancellationToken);
             Assert.True(validated, "Subscription should be validated after successful webhook delivery");
 
             // Assert - Validation queue should be empty

--- a/test/Altinn.Platform.Events.Tests/Altinn.Platform.Events.Tests.csproj
+++ b/test/Altinn.Platform.Events.Tests/Altinn.Platform.Events.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/AppControllerTests.cs
@@ -92,7 +92,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -127,7 +127,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -162,7 +162,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v3"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -196,7 +196,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -230,7 +230,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -263,7 +263,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "unittest"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -294,10 +294,10 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
                 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
                 
                 // Assert
-                var content = await response.Content.ReadAsStringAsync();
+                var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Verifies that the request object was rejected by ValidateRequiredProperties(), not by the controller's model-state filter.
@@ -331,7 +331,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
@@ -357,7 +357,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -385,7 +385,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -412,8 +412,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
@@ -442,8 +442,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
@@ -469,7 +469,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -497,8 +497,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 List<CloudEvent> actual = JsonSerializer.Deserialize<List<CloudEvent>>(responseString);
 
                 // Assert
@@ -529,8 +529,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 List<CloudEvent> actual = JsonSerializer.Deserialize<List<CloudEvent>>(responseString);
 
                 // Assert
@@ -561,8 +561,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 var actual = JsonSerializer.Deserialize<List<object>>(responseString);
 
                 // Assert
@@ -592,7 +592,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
@@ -619,8 +619,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(responseString, _options);
 
                 // Assert
@@ -649,8 +649,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(responseString, _options);
 
                 // Assert
@@ -679,8 +679,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
@@ -709,8 +709,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
@@ -739,8 +739,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
@@ -766,7 +766,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -795,8 +795,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 List<CloudEvent> actual = JsonSerializer.Deserialize<List<CloudEvent>>(responseString);
 
                 // Assert
@@ -830,8 +830,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("Person", "01038712345");
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 List<CloudEvent> actual = JsonSerializer.Deserialize<List<CloudEvent>>(responseString);
 
                 // Assert
@@ -863,8 +863,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 List<CloudEvent> actual = JsonSerializer.Deserialize<List<CloudEvent>>(responseString);
 
                 // Assert
@@ -896,8 +896,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 List<CloudEvent> actual = JsonSerializer.Deserialize<List<CloudEvent>>(responseString);
 
                 // Assert
@@ -927,7 +927,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
@@ -952,8 +952,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 List<CloudEvent> actual = JsonSerializer.Deserialize<List<CloudEvent>>(responseString);
 
                 // Assert
@@ -981,8 +981,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 var actual = JsonSerializer.Deserialize<ProblemDetails>(responseString, _options);
 
                 // Assert
@@ -1012,8 +1012,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 var actual = JsonSerializer.Deserialize<ProblemDetails>(responseString, _options);
 
                 // Assert
@@ -1041,8 +1041,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 var actual = JsonSerializer.Deserialize<ProblemDetails>(responseString, _options);
 
                 // Assert
@@ -1070,8 +1070,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 var actual = JsonSerializer.Deserialize<ProblemDetails>(responseString, _options);
 
                 // Assert
@@ -1099,8 +1099,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 var actual = JsonSerializer.Deserialize<ProblemDetails>(responseString, _options);
 
                 // Assert
@@ -1129,8 +1129,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("Person", "01038712345");
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 var actual = JsonSerializer.Deserialize<ProblemDetails>(responseString, _options);
 
                 // Assert

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/EventsControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/EventsControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -87,7 +87,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -108,7 +108,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events:invalid"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -130,8 +130,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events.publish"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseMessage = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseMessage = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -154,8 +154,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events.publish"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseMessage = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseMessage = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -177,7 +177,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
@@ -207,7 +207,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -238,7 +238,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "apps-test"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -269,7 +269,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "apps-test"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -293,7 +293,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -312,7 +312,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("digdir", scope: "altinn:events:invalid"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -342,7 +342,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -373,7 +373,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -401,8 +401,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
@@ -430,8 +430,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
@@ -460,8 +460,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("Altinn-AlternativeSubject", "person:16069412345");
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
@@ -490,8 +490,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 ProblemDetails actual = JsonSerializer.Deserialize<ProblemDetails>(content, _options);
 
                 // Assert
@@ -521,8 +521,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 List<CloudEvent> actual = JsonSerializer.Deserialize<List<CloudEvent>>(responseString);
 
                 // Assert
@@ -553,8 +553,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 var actual = JsonSerializer.Deserialize<List<object>>(responseString);
 
                 // Assert
@@ -584,7 +584,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
@@ -613,8 +613,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("Altinn-AlternativeSubject", "/person/01038712345");
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseString = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseString = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/InboundControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/InboundControllerTests.cs
@@ -85,7 +85,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -117,7 +117,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
@@ -143,7 +143,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -171,7 +171,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/LogsControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/LogsControllerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -76,7 +76,7 @@ public partial class IntegrationTests
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
             // Act
-            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
@@ -108,7 +108,7 @@ public partial class IntegrationTests
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
             // Act
-            HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+            HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -146,7 +146,7 @@ public partial class IntegrationTests
             httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
             // Act
-            var response = await client.SendAsync(httpRequestMessage);
+            var response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
             // Assert
             Assert.True(response.IsSuccessStatusCode);

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/OutboundControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/OutboundControllerTests.cs
@@ -81,7 +81,7 @@ public class OutboundControllerTests : IClassFixture<WebApplicationFactory<Outbo
         httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
         // Act
-        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -115,7 +115,7 @@ public class OutboundControllerTests : IClassFixture<WebApplicationFactory<Outbo
         httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
         // Act
-        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
@@ -141,7 +141,7 @@ public class OutboundControllerTests : IClassFixture<WebApplicationFactory<Outbo
         HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content };
 
         // Act
-        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -169,7 +169,7 @@ public class OutboundControllerTests : IClassFixture<WebApplicationFactory<Outbo
         HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content };
 
         // Act
-        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+        HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/StorageControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/StorageControllerTests.cs
@@ -83,7 +83,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.True(response.IsSuccessStatusCode);
@@ -114,7 +114,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("ttd", "endring-av-navn-v2"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
@@ -140,7 +140,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri) { Content = content };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -168,7 +168,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri) { Content = content };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
@@ -75,7 +75,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -98,7 +98,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -114,7 +114,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -131,8 +131,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 SubscriptionList actual = JsonSerializer.Deserialize<SubscriptionList>(content, _jsonOptions);
 
                 // Assert
@@ -152,8 +152,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 SubscriptionList actual = JsonSerializer.Deserialize<SubscriptionList>(content, _jsonOptions);
 
                 // Assert
@@ -173,8 +173,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 SubscriptionList actual = JsonSerializer.Deserialize<SubscriptionList>(content, _jsonOptions);
 
                 // Assert
@@ -200,7 +200,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -221,7 +221,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, requestUri);
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -239,7 +239,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 httpRequestMessage.Headers.Add("PlatformAccessToken", PrincipalUtil.GetAccessToken("platform", "events"));
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -267,7 +267,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -294,7 +294,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -324,8 +324,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseMessage = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseMessage = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -356,8 +356,8 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-                string responseMessage = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseMessage = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -383,7 +383,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -414,7 +414,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 serivceMock.Verify(s => s.CreateSubscription(It.IsAny<Subscription>()), Times.Once);
@@ -446,7 +446,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 serivceMock.Verify(s => s.CreateSubscription(It.IsAny<Subscription>()), Times.Once);
@@ -476,12 +476,12 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
-                string content = await response.Content.ReadAsStringAsync();
+                string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 Assert.Contains(cloudEventSubscription.SourceFilter.AbsoluteUri, content);
             }
 
@@ -511,7 +511,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 };
 
                 // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
 
                 // Assert
                 Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);

--- a/test/Altinn.Platform.Events.Tests/TestingFormatters/CloudEventJsonOutputFormatterTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingFormatters/CloudEventJsonOutputFormatterTests.cs
@@ -44,7 +44,7 @@ public class CloudEventJsonOutputFormatterTests
 
         // Assert
         httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
-        string result = await new StreamReader(httpContext.Response.Body).ReadToEndAsync();
+        string result = await new StreamReader(httpContext.Response.Body).ReadToEndAsync(TestContext.Current.CancellationToken);
         Assert.Contains("test-id", result);
     }
 
@@ -83,7 +83,7 @@ public class CloudEventJsonOutputFormatterTests
 
         // Assert
         httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
-        string result = await new StreamReader(httpContext.Response.Body).ReadToEndAsync();
+        string result = await new StreamReader(httpContext.Response.Body).ReadToEndAsync(TestContext.Current.CancellationToken);
         Assert.StartsWith("[", result);
         Assert.EndsWith("]", result);
         Assert.Contains("event-1", result);
@@ -120,7 +120,7 @@ public class CloudEventJsonOutputFormatterTests
 
         // Assert
         httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
-        string result = await new StreamReader(httpContext.Response.Body).ReadToEndAsync();
+        string result = await new StreamReader(httpContext.Response.Body).ReadToEndAsync(TestContext.Current.CancellationToken);
         Assert.DoesNotContain(", ", result);
     }
 

--- a/test/Altinn.Platform.Events.Tests/TestingServices/RegisterServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/RegisterServiceTest.cs
@@ -150,7 +150,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
                 "http://localhost:5101/register/api/v2/internal/parties/query?fields=identifiers";
             Assert.Equal(ExpectedRequestUri, requestMessage.RequestUri.ToString());
 
-            var requestContent = await requestMessage.Content.ReadFromJsonAsync<PartiesRegisterQueryRequest>();
+            var requestContent = await requestMessage.Content.ReadFromJsonAsync<PartiesRegisterQueryRequest>(TestContext.Current.CancellationToken);
             Assert.NotNull(requestContent);
             Assert.Equal(2, requestContent.Data.Length);
 
@@ -210,7 +210,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             Assert.Equal(HttpMethod.Post, firstRequestMessage.Method);
             Assert.Equal(ExpectedRequestUri, firstRequestMessage.RequestUri.ToString());
 
-            var firstRequestContent = await firstRequestMessage.Content.ReadFromJsonAsync<PartiesRegisterQueryRequest>();
+            var firstRequestContent = await firstRequestMessage.Content.ReadFromJsonAsync<PartiesRegisterQueryRequest>(TestContext.Current.CancellationToken);
             Assert.NotNull(firstRequestContent);
             Assert.Equal(2, firstRequestContent.Data.Length);
 
@@ -218,7 +218,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             Assert.Equal(HttpMethod.Post, secondRequestMessage.Method);
             Assert.Equal(ExpectedRequestUri, secondRequestMessage.RequestUri.ToString());
 
-            var secondRequestContent = await secondRequestMessage.Content.ReadFromJsonAsync<PartiesRegisterQueryRequest>();
+            var secondRequestContent = await secondRequestMessage.Content.ReadFromJsonAsync<PartiesRegisterQueryRequest>(TestContext.Current.CancellationToken);
             Assert.NotNull(secondRequestContent);
             Assert.Single(secondRequestContent.Data);
         }
@@ -430,7 +430,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             Assert.Equal(HttpMethod.Post, requestMessage.Method);
             Assert.Equal(ExpectedRequestUri, requestMessage.RequestUri.ToString());
 
-            var bodyJson = await requestMessage.Content.ReadAsStringAsync();
+            var bodyJson = await requestMessage.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
             Assert.Contains($"\"{OrgUrn}\"", bodyJson);
         }
 


### PR DESCRIPTION
## Description
Upgrade the test framework from xUnit to xUnit.v3. Fix all warnings from the new xUnit analyzer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Upgraded test framework from xUnit v2 to v3 across test projects.
  * Made HTTP and I/O calls in tests responsive to the current test cancellation token.
  * Converted async fixture lifecycle methods to use more efficient ValueTask patterns and sealed fixture types.

* **Chores**
  * Updated test project dependencies and package references to align with xUnit v3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->