### PR TITLE
Add CVE-2026-45447 to trivyignore

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,1 +1,4 @@
 vulnerabilities:
+  - id: CVE-2026-45447 # libcrypto3/libssl3
+    statement: The vulnerable code has no reachable execution path in our application
+    expired_at: 2026-06-18 # revisit in 1 week


### PR DESCRIPTION
The vulnerability isn't exploitable, but the trivy scan job still fails 