### PR TITLE
Fix invalid authorization of app events published by dialogporten for subscriptions

### DIFF
--- a/src/Events/Authorization/AppCloudEventXacmlMapper.cs
+++ b/src/Events/Authorization/AppCloudEventXacmlMapper.cs
@@ -76,8 +76,29 @@ public static class AppCloudEventXacmlMapper
             AccessSubject = [],
         };
 
-        (string applicationOwnerId, string appName, string instanceOwnerPartyId, string instanceGuid) = AppCloudEventExtensions.GetPropertiesFromAppSource(cloudEvent.Source);
-        
+        /* There are two possible publishers of events where the resource is an App: 
+         * The App itself and Dialogporten. The two publishers provide different properties, values and formats.
+         * See issue #930 for more details.
+         * */
+
+        string applicationOwnerId = null;
+        string appName = null;
+        string instanceId = null;
+        string subject = cloudEvent.Subject;
+
+        if (cloudEvent.Type?.StartsWith("app.") == true)
+        {
+            (applicationOwnerId, appName, var instanceOwnerPartyId, var instanceGuid) =
+                AppCloudEventExtensions.GetPropertiesFromAppSource(cloudEvent.Source);
+            instanceId = $"{instanceOwnerPartyId}/{instanceGuid}";
+        }
+        else
+        {
+            string[] appIdComponents = cloudEvent.GetResource().Split("_", 3);
+            applicationOwnerId = appIdComponents[1];
+            appName = appIdComponents[2];
+        }
+
         List<XacmlJsonCategory> subjectCategories = CreateMultipleSubjectCategories(consumers);
         request.AccessSubject.AddRange(subjectCategories);
 
@@ -85,7 +106,7 @@ public static class AppCloudEventXacmlMapper
         actionCategory.Id = $"{CloudEventXacmlMapper.ActionId}1";
         request.Action.Add(actionCategory);
 
-        var resourceCategory = CreateEventsResourceCategory(applicationOwnerId, appName, instanceOwnerPartyId, instanceGuid, true);
+        var resourceCategory = CreateEventsResourceCategory(applicationOwnerId, appName, subject, instanceId, true);
         resourceCategory.Id = $"{CloudEventXacmlMapper.ResourceId}1";
         request.Resource.Add(resourceCategory);
 
@@ -103,11 +124,11 @@ public static class AppCloudEventXacmlMapper
     /// </summary>
     /// <param name="applicationOwnerId">The identifier of the application owner.</param>
     /// <param name="appName">The name of the application.</param>
-    /// <param name="instanceOwnerPartyId">The identifier of the instance owner party.</param>
-    /// <param name="instanceGuid">The GUID of the instance.</param>
+    /// <param name="subject">The subject of the event.</param>
+    /// <param name="instanceId">The full instance id on the format {instanceOwnerPartyId}/{instanceGuid}.</param>
     /// <param name="includeResult">A boolean indicating whether to include the result in the attributes.</param>
     /// <returns>A <see cref="XacmlJsonCategory"/> object representing the resource category for events.</returns>
-    private static XacmlJsonCategory CreateEventsResourceCategory(string applicationOwnerId, string appName, string instanceOwnerPartyId, string instanceGuid, bool includeResult = false)
+    private static XacmlJsonCategory CreateEventsResourceCategory(string applicationOwnerId, string appName, string subject, string instanceId, bool includeResult = false)
     {
         string defaultType = CloudEventXacmlMapper.DefaultType;
         string defaultIssuer = CloudEventXacmlMapper.DefaultIssuer;
@@ -117,14 +138,14 @@ public static class AppCloudEventXacmlMapper
             Attribute = []
         };
 
-        if (!string.IsNullOrWhiteSpace(instanceOwnerPartyId))
+        if (!string.IsNullOrWhiteSpace(subject))
         {
-            resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.PartyId, instanceOwnerPartyId, defaultType, defaultIssuer, includeResult));
+            resourceCategory.AddSubjectAttribute(subject, includeResult);
         }
 
-        if (!string.IsNullOrWhiteSpace(instanceGuid) && !string.IsNullOrWhiteSpace(instanceOwnerPartyId))
+        if (!string.IsNullOrWhiteSpace(instanceId))
         {
-            resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.InstanceId, instanceOwnerPartyId + "/" + instanceGuid, defaultType, defaultIssuer, includeResult));
+            resourceCategory.Attribute.Add(DecisionHelper.CreateXacmlJsonAttribute(AltinnXacmlUrns.InstanceId, instanceId, defaultType, defaultIssuer, includeResult));
         }
 
         if (!string.IsNullOrWhiteSpace(applicationOwnerId))

--- a/src/Events/Extensions/UriExtensions.cs
+++ b/src/Events/Extensions/UriExtensions.cs
@@ -1,33 +1,28 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Altinn.Platform.Events.Extensions
+namespace Altinn.Platform.Events.Extensions;
+
+/// <summary>
+/// Contains a collection of helper methods for <see cref="Uri"/> and uri strings.
+/// </summary>
+public static class UriExtensions
 {
+    private static string _urnPattern = @"^urn:[a-z0-9-]{1,30}(:[a-z0-9()+,.\-;$_!\/]{1,100}){1,10}$";
+
     /// <summary>
-    /// Class for extension methods related to hashing a uri
+    ///  Validates that the provided uri is a urn or an url with the https scheme.
     /// </summary>
-    public static class UriExtensions
+    public static bool IsValidUrlOrUrn(Uri uri)
     {
-        private static string _urnPattern = @"^urn:[a-z0-9-]{1,30}(:[a-z0-9()+,.\-;$_!\/]{1,100}){1,10}$";
+        return uri.Scheme == "https" || IsValidUrn(uri.ToString());
+    }
 
-        /// <summary>
-        ///  Validates that the provided uri is a urn or an url with the https scheme.
-        /// </summary>
-        public static bool IsValidUrlOrUrn(Uri uri)
-        {
-            return uri.Scheme == "https" || IsValidUrn(uri.ToString());
-        }
-
-        /// <summary>
-        ///  Validates that the provided uri is a urn.
-        /// </summary>
-        public static bool IsValidUrn(string potentialUrn)
-        {
-            return Uri.IsWellFormedUriString(potentialUrn, UriKind.Absolute) && Regex.IsMatch(potentialUrn, _urnPattern, RegexOptions.None, TimeSpan.FromSeconds(0.5));
-        }
+    /// <summary>
+    ///  Validates that the provided uri is a urn.
+    /// </summary>
+    public static bool IsValidUrn(string potentialUrn)
+    {
+        return Uri.IsWellFormedUriString(potentialUrn, UriKind.Absolute) && Regex.IsMatch(potentialUrn, _urnPattern, RegexOptions.None, TimeSpan.FromSeconds(0.5));
     }
 }

--- a/src/Events/Services/AuthorizationService.cs
+++ b/src/Events/Services/AuthorizationService.cs
@@ -188,7 +188,7 @@ public class AuthorizationService : IAuthorization
 
         RestoreSubject(cloudEvent);
 
-        XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
+        XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest, cancellationToken);
             
         foreach (var r in response.Response)
         {

--- a/src/Events/Services/AuthorizationService.cs
+++ b/src/Events/Services/AuthorizationService.cs
@@ -170,10 +170,24 @@ public class AuthorizationService : IAuthorization
 
     /// <inheritdoc/>
     public async Task<Dictionary<string, bool>> AuthorizeMultipleConsumersForAltinnAppEvent(
-        CloudEvent cloudEvent, List<string> consumers)
+        CloudEvent cloudEvent, List<string> consumers, CancellationToken cancellationToken)
     {
-        var results = new Dictionary<string, bool>();
+        var results = new Dictionary<string, bool>(); 
+
+        if (UnsupportedSubject(cloudEvent))
+        {
+            /* App events published by Dialogportan might contain subjects not supported by Authorization. */
+
+            IEnumerable<PartyIdentifiers> partyIdentifiersList =
+                await _registerService.PartyLookup([cloudEvent.Subject!], cancellationToken);
+
+            ReplaceSubject(cloudEvent, partyIdentifiersList);
+        }
+
         XacmlJsonRequestRoot xacmlJsonRequest = AppCloudEventXacmlMapper.CreateMultiDecisionRequestForMultipleConsumers(cloudEvent, consumers);
+
+        RestoreSubject(cloudEvent);
+
         XacmlJsonResponse response = await _pdp.GetDecisionForRequest(xacmlJsonRequest);
             
         foreach (var r in response.Response)
@@ -239,6 +253,7 @@ public class AuthorizationService : IAuthorization
 
     private static bool UnsupportedSubject(CloudEvent e)
     {
+        // The internal Authorization endpoints doesn't allow the use of national identity number as subject.
         return e.Subject is not null && e.Subject.StartsWith("urn:altinn:person:identifier-no:");
     }
 

--- a/src/Events/Services/Interfaces/IAuthorization.cs
+++ b/src/Events/Services/Interfaces/IAuthorization.cs
@@ -42,37 +42,53 @@ namespace Altinn.Platform.Events.Services.Interfaces
         public Task<bool> AuthorizePublishEvent(CloudEvent cloudEvent, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Authorizes multiple consumers for a specified Altinn application event and returns the authorization status for
-        /// each consumer.
+        /// Authorizes multiple consumers for a specified Altinn application event and returns the authorization 
+        /// status for each consumer.
         /// </summary>
-        /// <remarks>The method performs authorization checks for all provided consumers in a single request. The
-        /// returned dictionary contains an entry for each consumer in the input list. If a consumer is not authorized, its
-        /// value will be <see langword="false"/>.</remarks>
-        /// <param name="cloudEvent">The cloud event representing the Altinn application event for which authorization is being evaluated.</param>
-        /// <param name="consumers">A list of consumer identifiers to be authorized for the specified event. Each identifier should correspond to a
-        /// valid consumer.</param>
-        /// <returns>A dictionary mapping each consumer identifier to a Boolean value indicating whether the consumer is authorized
-        /// (<see langword="true"/>) or not (<see langword="false"/>).</returns>
+        /// <remarks>The method performs authorization checks for all provided consumers in a single request.
+        /// The returned dictionary contains an entry for each consumer in the input list. If a consumer is not
+        /// authorized, its value will be <see langword="false"/>.</remarks>
+        /// <param name="cloudEvent">
+        /// The cloud event representing the Altinn application event for which authorization is being evaluated.
+        /// </param>
+        /// <param name="consumers">
+        /// A list of consumer identifiers to be authorized for the specified event. Each identifier should 
+        /// correspond to a valid consumer.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used to cancel the authorization operation.
+        /// </param>
+        /// <returns>A dictionary mapping each consumer identifier to a Boolean value indicating whether the
+        /// consumer is authorized (<see langword="true"/>) or not (<see langword="false"/>).</returns>
         public Task<Dictionary<string, bool>> AuthorizeMultipleConsumersForAltinnAppEvent(
-            CloudEvent cloudEvent, List<string> consumers);
+            CloudEvent cloudEvent, List<string> consumers, CancellationToken cancellationToken);
 
         /// <summary>
         /// Method to authorize access to create an Altinn App Events Subscription
         /// </summary>
-        /// <param name="subscription">The subscription to be authorized containing source and consumer details</param>
+        /// <param name="subscription">
+        /// The subscription to be authorized containing source and consumer details.
+        /// </param>
         /// <returns>A boolean indicating if the consumer is authorized or not</returns>
         public Task<bool> AuthorizeConsumerForEventsSubscription(Subscription subscription);
 
         /// <summary>
         /// Determines whether each specified consumer is authorized to access the given generic cloud event.
         /// </summary>
-        /// <param name="cloudEvent">The cloud event for which authorization is being checked. Cannot be null.</param>
-        /// <param name="consumers">A list of consumer identifiers to evaluate for authorization. Cannot be null or contain null or empty
-        /// values.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used to cancel the authorization operation.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains a dictionary mapping each
+        /// <param name="cloudEvent">
+        /// The cloud event for which authorization is being checked. Cannot be null.
+        /// </param>
+        /// <param name="consumers">
+        /// A list of consumer identifiers to evaluate for authorization. Cannot be null or contain null or 
+        /// empty values.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used to cancel the authorization operation.
+        /// </param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains a dictionary mapping each
         /// consumer identifier to a boolean value indicating whether the consumer is authorized (<see
         /// langword="true"/>) or not (<see langword="false"/>).</returns>
-        public Task<Dictionary<string, bool>> AuthorizeMultipleConsumersForGenericEvent(CloudEvent cloudEvent, List<string> consumers, CancellationToken cancellationToken);
+        public Task<Dictionary<string, bool>> AuthorizeMultipleConsumersForGenericEvent(
+            CloudEvent cloudEvent, List<string> consumers, CancellationToken cancellationToken);
     }
 }

--- a/src/Events/Services/OutboundService.cs
+++ b/src/Events/Services/OutboundService.cs
@@ -114,6 +114,12 @@ public class OutboundService : IOutboundService
             }
         }
 
+        if (cloudEvent.Source is not null)
+        {
+            allSubscriptions.RemoveAll(
+                sub => sub.SourceFilter is not null && !sub.SourceFilter.IsBaseOf(cloudEvent.Source));
+        }
+
         await AuthorizeAndPush(cloudEvent, allSubscriptions, cancellationToken, useAzureServiceBus);
     }
 

--- a/src/Events/Services/OutboundService.cs
+++ b/src/Events/Services/OutboundService.cs
@@ -283,12 +283,14 @@ public class OutboundService : IOutboundService
         if (isAppEvent)
         {
             // App events are authorized for action "read" on app resource "events"
-            authorizationResult = await _authorizationService.AuthorizeMultipleConsumersForAltinnAppEvent(cloudEvent, unauthorizedConsumers);
+            authorizationResult = await _authorizationService.AuthorizeMultipleConsumersForAltinnAppEvent(
+                cloudEvent, unauthorizedConsumers, cancellationToken);
         }
         else
         {
             // Generic events use "subscribe" action for authorization
-            authorizationResult = await _authorizationService.AuthorizeMultipleConsumersForGenericEvent(cloudEvent, unauthorizedConsumers, cancellationToken);
+            authorizationResult = await _authorizationService.AuthorizeMultipleConsumersForGenericEvent(
+                cloudEvent, unauthorizedConsumers, cancellationToken);
         }
             
         CacheResults(authorizationResult, cacheKeys);

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingControllers/EndToEndEventFlowTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingControllers/EndToEndEventFlowTests.cs
@@ -53,8 +53,8 @@ public class EndToEndEventFlowTests(IntegrationTestContainersFixture fixture)
         authMock.Setup(a => a.AuthorizeConsumerForEventsSubscription(It.IsAny<Subscription>()))
             .ReturnsAsync(true);
         authMock.Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
-                It.IsAny<CloudEvent>(), It.IsAny<List<string>>()))
-            .ReturnsAsync((CloudEvent _, List<string> consumers) =>
+                It.IsAny<CloudEvent>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CloudEvent _, List<string> consumers, CancellationToken _) =>
                 consumers.ToDictionary(c => c, _ => true));
         authMock.Setup(a => a.AuthorizeMultipleConsumersForGenericEvent(
                 It.IsAny<CloudEvent>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))

--- a/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/InboundQueueRetryTests.cs
+++ b/test/Altinn.Platform.Events.IntegrationTests/TestingServiceBus/InboundQueueRetryTests.cs
@@ -37,8 +37,8 @@ public class InboundQueueRetryTests(IntegrationTestContainersFixture fixture)
         // Arrange - Mock auth to authorize all consumers
         var authMock = new Mock<IAuthorization>();
         authMock.Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
-                It.IsAny<CloudEvent>(), It.IsAny<List<string>>()))
-            .ReturnsAsync((CloudEvent _, List<string> consumers) =>
+                It.IsAny<CloudEvent>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CloudEvent _, List<string> consumers, CancellationToken _) =>
                 consumers.ToDictionary(c => c, _ => true));
         authMock.Setup(a => a.AuthorizeMultipleConsumersForGenericEvent(
                 It.IsAny<CloudEvent>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))

--- a/test/Altinn.Platform.Events.Tests/Constants/XacmlRequestAttribute.cs
+++ b/test/Altinn.Platform.Events.Tests/Constants/XacmlRequestAttribute.cs
@@ -1,50 +1,54 @@
-namespace Altinn.Platform.Storage.UnitTest.Constants
+namespace Altinn.Platform.Events.Tests.Constants;
+
+public static class XacmlRequestAttribute
 {
-    public static class XacmlRequestAttribute
-    {
-        /// <summary>
-        /// xacml string that represents org
-        /// </summary>
-        public const string OrgAttribute = "urn:altinn:org";
+    /// <summary>
+    /// xacml string that represents org
+    /// </summary>
+    public const string OrgAttribute = "urn:altinn:org";
 
-        /// <summary>
-        /// xacml string that represents app
-        /// </summary>
-        public const string AppAttribute = "urn:altinn:app";
+    /// <summary>
+    /// xacml string that represents app
+    /// </summary>
+    public const string AppAttribute = "urn:altinn:app";
 
-        /// <summary>
-        /// xacml string that represents isntance
-        /// </summary>
-        public const string InstanceAttribute = "urn:altinn:instance-id";
+    /// <summary>
+    /// xacml string that represents isntance
+    /// </summary>
+    public const string InstanceAttribute = "urn:altinn:instance-id";
 
-        /// <summary>
-        /// xacm string that represents appresource
-        /// </summary>
-        public const string AppResourceAttribute = "urn:altinn:appresource";
+    /// <summary>
+    /// xacm string that represents appresource
+    /// </summary>
+    public const string AppResourceAttribute = "urn:altinn:appresource";
 
-        /// <summary>
-        /// xacml string that represents task
-        /// </summary>
-        public const string TaskAttribute = "urn:altinn:task";
+    /// <summary>
+    /// xacml string that represents task
+    /// </summary>
+    public const string TaskAttribute = "urn:altinn:task";
 
-        /// <summary>
-        /// xacml string that represents end event
-        /// </summary>
-        public const string EndEventAttribute = "urn:altinn:end-event";
+    /// <summary>
+    /// xacml string that represents end event
+    /// </summary>
+    public const string EndEventAttribute = "urn:altinn:end-event";
 
-        /// <summary>
-        /// xacml string that represents party
-        /// </summary>
-        public const string PartyAttribute = "urn:altinn:partyid";
+    /// <summary>
+    /// xacml string that represents party
+    /// </summary>
+    public const string PartyAttribute = "urn:altinn:partyid"; // urn:altinn:organization:identifier-no
 
-        /// <summary>
-        /// xacml string that represents user
-        /// </summary>
-        public const string UserAttribute = "urn:altinn:userid";
+    /// <summary>
+    /// xacml string that represents organization
+    /// </summary>
+    public const string OrganizationAttribute = "urn:altinn:organization:identifier-no";
 
-        /// <summary>
-        /// xacml string that represents role
-        /// </summary>
-        public const string RoleAttribute = "urn:altinn:rolecode";
-    }
+    /// <summary>
+    /// xacml string that represents user
+    /// </summary>
+    public const string UserAttribute = "urn:altinn:userid";
+
+    /// <summary>
+    /// xacml string that represents role
+    /// </summary>
+    public const string RoleAttribute = "urn:altinn:rolecode";
 }

--- a/test/Altinn.Platform.Events.Tests/Data/Roles/User_1337/party_50301578/roles.json
+++ b/test/Altinn.Platform.Events.Tests/Data/Roles/User_1337/party_50301578/roles.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Type": "altinn",
+    "value": "REGNA"
+  }
+]

--- a/test/Altinn.Platform.Events.Tests/Mocks/PepWithPDPAuthorizationMockSI.cs
+++ b/test/Altinn.Platform.Events.Tests/Mocks/PepWithPDPAuthorizationMockSI.cs
@@ -12,309 +12,309 @@ using Altinn.Authorization.ABAC.Constants;
 using Altinn.Authorization.ABAC.Utils;
 using Altinn.Authorization.ABAC.Xacml;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
+
 using Altinn.Common.PEP.Helpers;
 using Altinn.Common.PEP.Interfaces;
 using Altinn.Platform.Event.Tests.Models;
-using Altinn.Platform.Storage.UnitTest.Constants;
+using Altinn.Platform.Events.Tests.Constants;
 
 using Authorization.Platform.Authorization.Models;
 
 using Newtonsoft.Json;
 
-namespace Altinn.Platform.Events.UnitTest.Mocks
+namespace Altinn.Platform.Events.UnitTest.Mocks;
+
+public class PepWithPDPAuthorizationMockSI : IPDP
 {
-    public class PepWithPDPAuthorizationMockSI : IPDP
+    private readonly string orgAttributeId = "urn:altinn:org";
+
+    private readonly string appAttributeId = "urn:altinn:app";
+
+    private readonly string userAttributeId = "urn:altinn:userid";
+
+    private readonly string altinnRoleAttributeId = "urn:altinn:rolecode";
+
+    public PepWithPDPAuthorizationMockSI()
     {
-        private readonly string orgAttributeId = "urn:altinn:org";
-
-        private readonly string appAttributeId = "urn:altinn:app";
-
-        private readonly string userAttributeId = "urn:altinn:userid";
-
-        private readonly string altinnRoleAttributeId = "urn:altinn:rolecode";
-
-        public PepWithPDPAuthorizationMockSI()
-        {
-        }
-
-        public async Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest)
-        {
-            return await Authorize(xacmlJsonRequest.Request);
-        }
-
-        public Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        private async Task<XacmlJsonResponse> Authorize(XacmlJsonRequest decisionRequest)
-        {
-            if (decisionRequest.MultiRequests == null || decisionRequest.MultiRequests.RequestReference == null
-                || decisionRequest.MultiRequests.RequestReference.Count < 2)
-            {
-                XacmlContextRequest request = XacmlJsonXmlConverter.ConvertRequest(decisionRequest);
-                XacmlContextResponse xmlResponse = await Authorize(request);
-                return XacmlJsonXmlConverter.ConvertResponse(xmlResponse);
-            }
-            else
-            {
-                XacmlJsonResponse multiResponse = new XacmlJsonResponse();
-                foreach (XacmlJsonRequestReference xacmlJsonRequestReference in decisionRequest.MultiRequests.RequestReference)
-                {
-                    XacmlJsonRequest jsonMultiRequestPart = new XacmlJsonRequest();
-
-                    foreach (string refer in xacmlJsonRequestReference.ReferenceId)
-                    {
-                        List<XacmlJsonCategory> resourceCategoriesPart = decisionRequest.Resource.Where(i => i.Id.Equals(refer)).ToList();
-
-                        if (resourceCategoriesPart.Count > 0)
-                        {
-                            if (jsonMultiRequestPart.Resource == null)
-                            {
-                                jsonMultiRequestPart.Resource = new List<XacmlJsonCategory>();
-                            }
-
-                            jsonMultiRequestPart.Resource.AddRange(resourceCategoriesPart);
-                        }
-
-                        List<XacmlJsonCategory> subjectCategoriesPart = decisionRequest.AccessSubject.Where(i => i.Id.Equals(refer)).ToList();
-
-                        if (subjectCategoriesPart.Count > 0)
-                        {
-                            if (jsonMultiRequestPart.AccessSubject == null)
-                            {
-                                jsonMultiRequestPart.AccessSubject = new List<XacmlJsonCategory>();
-                            }
-
-                            jsonMultiRequestPart.AccessSubject.AddRange(subjectCategoriesPart);
-                        }
-
-                        List<XacmlJsonCategory> actionCategoriesPart = decisionRequest.Action.Where(i => i.Id.Equals(refer)).ToList();
-
-                        if (actionCategoriesPart.Count > 0)
-                        {
-                            if (jsonMultiRequestPart.Action == null)
-                            {
-                                jsonMultiRequestPart.Action = new List<XacmlJsonCategory>();
-                            }
-
-                            jsonMultiRequestPart.Action.AddRange(actionCategoriesPart);
-                        }
-                    }
-
-                    XacmlContextResponse partResponse = await Authorize(XacmlJsonXmlConverter.ConvertRequest(jsonMultiRequestPart));
-                    XacmlJsonResponse xacmlJsonResponsePart = XacmlJsonXmlConverter.ConvertResponse(partResponse);
-
-                    if (multiResponse.Response == null)
-                    {
-                        multiResponse.Response = new List<XacmlJsonResult>();
-                    }
-
-                    multiResponse.Response.Add(xacmlJsonResponsePart.Response.First());
-                }
-
-                return multiResponse;
-            }
-        }
-
-        private async Task<XacmlContextResponse> Authorize(XacmlContextRequest decisionRequest)
-        {
-            decisionRequest = await Enrich(decisionRequest);
-
-            XacmlPolicy policy = await GetPolicyAsync(decisionRequest);
-
-            PolicyDecisionPoint pdp = new PolicyDecisionPoint();
-            XacmlContextResponse xacmlContextResponse = pdp.Authorize(decisionRequest, policy);
-
-            return xacmlContextResponse;
-        }
-
-        public async Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user)
-        {
-            XacmlJsonResponse response = await GetDecisionForRequest(xacmlJsonRequest);
-            return DecisionHelper.ValidatePdpDecision(response.Response, user);
-        }
-
-        public Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request)
-        {
-            await EnrichResourceAttributes(request);
-
-            return request;
-        }
-
-        private async Task EnrichResourceAttributes(XacmlContextRequest request)
-        {
-            XacmlContextAttributes resourceContextAttributes = request.GetResourceAttributes();
-            XacmlResourceAttributes resourceAttributes = GetResourceAttributeValues(resourceContextAttributes);
-
-            await EnrichSubjectAttributes(request, resourceAttributes.ResourcePartyValue);
-        }
-
-        private async Task EnrichSubjectAttributes(XacmlContextRequest request, string resourceParty)
-        {
-            // If there is no resource party then it is impossible to enrich roles
-            if (string.IsNullOrEmpty(resourceParty))
-            {
-                return;
-            }
-
-            XacmlContextAttributes subjectContextAttributes = request.GetSubjectAttributes();
-
-            int subjectUserId = 0;
-            int resourcePartyId = Convert.ToInt32(resourceParty);
-
-            foreach (XacmlAttribute xacmlAttribute in subjectContextAttributes.Attributes)
-            {
-                if (xacmlAttribute.AttributeId.OriginalString.Equals(userAttributeId))
-                {
-                    subjectUserId = Convert.ToInt32(xacmlAttribute.AttributeValues.First().Value);
-                }
-            }
-
-            if (subjectUserId == 0)
-            {
-                return;
-            }
-
-            List<Role> roleList = await GetDecisionPointRolesForUser(subjectUserId, resourcePartyId) ?? new List<Role>();
-
-            subjectContextAttributes.Attributes.Add(GetRoleAttribute(roleList));
-        }
-
-        private static XacmlResourceAttributes GetResourceAttributeValues(XacmlContextAttributes resourceContextAttributes)
-        {
-            XacmlResourceAttributes resourceAttributes = new XacmlResourceAttributes();
-
-            foreach (XacmlAttribute attribute in resourceContextAttributes.Attributes)
-            {
-                if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.OrgAttribute))
-                {
-                    resourceAttributes.OrgValue = attribute.AttributeValues.First().Value;
-                }
-
-                if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.AppAttribute))
-                {
-                    resourceAttributes.AppValue = attribute.AttributeValues.First().Value;
-                }
-
-                if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.InstanceAttribute))
-                {
-                    resourceAttributes.InstanceValue = attribute.AttributeValues.First().Value;
-                }
-
-                if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.PartyAttribute))
-                {
-                    resourceAttributes.ResourcePartyValue = attribute.AttributeValues.First().Value;
-                }
-
-                if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.TaskAttribute))
-                {
-                    resourceAttributes.TaskValue = attribute.AttributeValues.First().Value;
-                }
-
-                if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.AppResourceAttribute))
-                {
-                    resourceAttributes.AppResourceValue = attribute.AttributeValues.First().Value;
-                }
-            }
-
-            return resourceAttributes;
-        }
-
-        private XacmlAttribute GetRoleAttribute(List<Role> roles)
-        {
-            XacmlAttribute attribute = new XacmlAttribute(new Uri(altinnRoleAttributeId), false);
-            foreach (Role role in roles)
-            {
-                attribute.AttributeValues.Add(new XacmlAttributeValue(new Uri(XacmlConstants.DataTypes.XMLString), role.Value));
-            }
-
-            return attribute;
-        }
-
-        public static Task<List<Role>> GetDecisionPointRolesForUser(int coveredByUserId, int offeredByPartyId)
-        {
-            string rolesPath = GetRolesPath(coveredByUserId, offeredByPartyId);
-
-            List<Role> roles = new List<Role>();
-
-            if (File.Exists(rolesPath))
-            {
-                string content = File.ReadAllText(rolesPath);
-                roles = (List<Role>)JsonConvert.DeserializeObject(content, typeof(List<Role>));
-            }
-
-            return Task.FromResult(roles);
-        }
-
-        private static string GetRolesPath(int userId, int resourcePartyId)
-        {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMockSI).Assembly.Location).LocalPath);
-            return Path.Combine(unitTestFolder, "..", "..", "..", "Data", "Roles", "User_" + userId, "party_" + resourcePartyId, "roles.json");
-        }
-
-        private async Task<XacmlPolicy> GetPolicyAsync(XacmlContextRequest request)
-        {
-            XacmlPolicy xacmlPolicy = ParsePolicy("policy.xml", GetPolicyPath(request));
-            return await Task.FromResult(xacmlPolicy);
-        }
-
-        private string GetPolicyPath(XacmlContextRequest request)
-        {
-            string org = string.Empty;
-            string app = string.Empty;
-            foreach (XacmlContextAttributes attr in request.Attributes)
-            {
-                if (attr.Category.OriginalString.Equals(XacmlConstants.MatchAttributeCategory.Resource))
-                {
-                    foreach (XacmlAttribute asd in attr.Attributes)
-                    {
-                        if (asd.AttributeId.OriginalString.Equals(orgAttributeId))
-                        {
-                            foreach (var asff in asd.AttributeValues)
-                            {
-                                org = asff.Value;
-                                break;
-                            }
-                        }
-
-                        if (asd.AttributeId.OriginalString.Equals(appAttributeId))
-                        {
-                            foreach (var asff in asd.AttributeValues)
-                            {
-                                app = asff.Value;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            return GetAltinnAppsPolicyPath(org, app);
-        }
-
-        public static XacmlPolicy ParsePolicy(string policyDocumentTitle, string policyPath)
-        {
-            XmlDocument policyDocument = new XmlDocument();
-            policyDocument.Load(Path.Combine(policyPath, policyDocumentTitle));
-            XacmlPolicy policy;
-            using (XmlReader reader = XmlReader.Create(new StringReader(policyDocument.OuterXml)))
-            {
-                policy = XacmlParser.ParseXacmlPolicy(reader);
-            }
-
-            return policy;
-        }
-
-        private static string GetAltinnAppsPolicyPath(string org, string app)
-        {
-            string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMockSI).Assembly.Location).LocalPath);
-            return Path.Combine(unitTestFolder, "..", "..", "..", "Data", "apps", org, app, "config", "authorization");
-        }              
     }
+
+    public async Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest)
+    {
+        return await Authorize(xacmlJsonRequest.Request);
+    }
+
+    public async Task<XacmlJsonResponse> GetDecisionForRequest(XacmlJsonRequestRoot xacmlJsonRequest, CancellationToken cancellationToken)
+    {
+        return await Authorize(xacmlJsonRequest.Request);
+    }
+
+    private async Task<XacmlJsonResponse> Authorize(XacmlJsonRequest decisionRequest)
+    {
+        if (decisionRequest.MultiRequests == null || decisionRequest.MultiRequests.RequestReference == null
+            || decisionRequest.MultiRequests.RequestReference.Count < 2)
+        {
+            XacmlContextRequest request = XacmlJsonXmlConverter.ConvertRequest(decisionRequest);
+            XacmlContextResponse xmlResponse = await Authorize(request);
+            return XacmlJsonXmlConverter.ConvertResponse(xmlResponse);
+        }
+        else
+        {
+            XacmlJsonResponse multiResponse = new XacmlJsonResponse();
+            foreach (XacmlJsonRequestReference xacmlJsonRequestReference in decisionRequest.MultiRequests.RequestReference)
+            {
+                XacmlJsonRequest jsonMultiRequestPart = new XacmlJsonRequest();
+
+                foreach (string refer in xacmlJsonRequestReference.ReferenceId)
+                {
+                    List<XacmlJsonCategory> resourceCategoriesPart = decisionRequest.Resource.Where(i => i.Id.Equals(refer)).ToList();
+
+                    if (resourceCategoriesPart.Count > 0)
+                    {
+                        if (jsonMultiRequestPart.Resource == null)
+                        {
+                            jsonMultiRequestPart.Resource = new List<XacmlJsonCategory>();
+                        }
+
+                        jsonMultiRequestPart.Resource.AddRange(resourceCategoriesPart);
+                    }
+
+                    List<XacmlJsonCategory> subjectCategoriesPart = decisionRequest.AccessSubject.Where(i => i.Id.Equals(refer)).ToList();
+
+                    if (subjectCategoriesPart.Count > 0)
+                    {
+                        if (jsonMultiRequestPart.AccessSubject == null)
+                        {
+                            jsonMultiRequestPart.AccessSubject = new List<XacmlJsonCategory>();
+                        }
+
+                        jsonMultiRequestPart.AccessSubject.AddRange(subjectCategoriesPart);
+                    }
+
+                    List<XacmlJsonCategory> actionCategoriesPart = decisionRequest.Action.Where(i => i.Id.Equals(refer)).ToList();
+
+                    if (actionCategoriesPart.Count > 0)
+                    {
+                        if (jsonMultiRequestPart.Action == null)
+                        {
+                            jsonMultiRequestPart.Action = new List<XacmlJsonCategory>();
+                        }
+
+                        jsonMultiRequestPart.Action.AddRange(actionCategoriesPart);
+                    }
+                }
+
+                XacmlContextResponse partResponse = await Authorize(XacmlJsonXmlConverter.ConvertRequest(jsonMultiRequestPart));
+                XacmlJsonResponse xacmlJsonResponsePart = XacmlJsonXmlConverter.ConvertResponse(partResponse);
+
+                if (multiResponse.Response == null)
+                {
+                    multiResponse.Response = new List<XacmlJsonResult>();
+                }
+
+                multiResponse.Response.Add(xacmlJsonResponsePart.Response.First());
+            }
+
+            return multiResponse;
+        }
+    }
+
+    private async Task<XacmlContextResponse> Authorize(XacmlContextRequest decisionRequest)
+    {
+        decisionRequest = await Enrich(decisionRequest);
+
+        XacmlPolicy policy = await GetPolicyAsync(decisionRequest);
+
+        PolicyDecisionPoint pdp = new PolicyDecisionPoint();
+        XacmlContextResponse xacmlContextResponse = pdp.Authorize(decisionRequest, policy);
+
+        return xacmlContextResponse;
+    }
+
+    public async Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user)
+    {
+        XacmlJsonResponse response = await GetDecisionForRequest(xacmlJsonRequest);
+        return DecisionHelper.ValidatePdpDecision(response.Response, user);
+    }
+
+    public Task<bool> GetDecisionForUnvalidateRequest(XacmlJsonRequestRoot xacmlJsonRequest, ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request)
+    {
+        await EnrichResourceAttributes(request);
+
+        return request;
+    }
+
+    private async Task EnrichResourceAttributes(XacmlContextRequest request)
+    {
+        XacmlContextAttributes resourceContextAttributes = request.GetResourceAttributes();
+        XacmlResourceAttributes resourceAttributes = GetResourceAttributeValues(resourceContextAttributes);
+
+        await EnrichSubjectAttributes(request, resourceAttributes.ResourcePartyValue);
+    }
+
+    private async Task EnrichSubjectAttributes(XacmlContextRequest request, string resourceParty)
+    {
+        // If there is no resource party then it is impossible to enrich roles
+        if (string.IsNullOrEmpty(resourceParty))
+        {
+            return;
+        }
+
+        XacmlContextAttributes subjectContextAttributes = request.GetSubjectAttributes();
+
+        int subjectUserId = 0;
+
+        foreach (XacmlAttribute xacmlAttribute in subjectContextAttributes.Attributes)
+        {
+            if (xacmlAttribute.AttributeId.OriginalString.Equals(userAttributeId))
+            {
+                subjectUserId = Convert.ToInt32(xacmlAttribute.AttributeValues.First().Value);
+            }
+        }
+
+        if (subjectUserId == 0)
+        {
+            return;
+        }
+
+        int resourcePartyId = Convert.ToInt32(resourceParty);
+        List<Role> roleList = await GetDecisionPointRolesForUser(subjectUserId, resourcePartyId) ?? new List<Role>();
+
+        subjectContextAttributes.Attributes.Add(GetRoleAttribute(roleList));
+    }
+
+    private static XacmlResourceAttributes GetResourceAttributeValues(XacmlContextAttributes resourceContextAttributes)
+    {
+        XacmlResourceAttributes resourceAttributes = new XacmlResourceAttributes();
+
+        foreach (XacmlAttribute attribute in resourceContextAttributes.Attributes)
+        {
+            if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.OrgAttribute))
+            {
+                resourceAttributes.OrgValue = attribute.AttributeValues.First().Value;
+            }
+
+            if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.AppAttribute))
+            {
+                resourceAttributes.AppValue = attribute.AttributeValues.First().Value;
+            }
+
+            if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.InstanceAttribute))
+            {
+                resourceAttributes.InstanceValue = attribute.AttributeValues.First().Value;
+            }
+
+            if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.PartyAttribute))
+            {
+                resourceAttributes.ResourcePartyValue = attribute.AttributeValues.First().Value;
+            }
+
+            if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.TaskAttribute))
+            {
+                resourceAttributes.TaskValue = attribute.AttributeValues.First().Value;
+            }
+
+            if (attribute.AttributeId.OriginalString.Equals(XacmlRequestAttribute.AppResourceAttribute))
+            {
+                resourceAttributes.AppResourceValue = attribute.AttributeValues.First().Value;
+            }
+        }
+
+        return resourceAttributes;
+    }
+
+    private XacmlAttribute GetRoleAttribute(List<Role> roles)
+    {
+        XacmlAttribute attribute = new XacmlAttribute(new Uri(altinnRoleAttributeId), false);
+        foreach (Role role in roles)
+        {
+            attribute.AttributeValues.Add(new XacmlAttributeValue(new Uri(XacmlConstants.DataTypes.XMLString), role.Value));
+        }
+
+        return attribute;
+    }
+
+    public static Task<List<Role>> GetDecisionPointRolesForUser(int coveredByUserId, int offeredByPartyId)
+    {
+        string rolesPath = GetRolesPath(coveredByUserId, offeredByPartyId);
+
+        List<Role> roles = new List<Role>();
+
+        if (File.Exists(rolesPath))
+        {
+            string content = File.ReadAllText(rolesPath);
+            roles = (List<Role>)JsonConvert.DeserializeObject(content, typeof(List<Role>));
+        }
+
+        return Task.FromResult(roles);
+    }
+
+    private static string GetRolesPath(int userId, int resourcePartyId)
+    {
+        string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMockSI).Assembly.Location).LocalPath);
+        return Path.Combine(unitTestFolder, "..", "..", "..", "Data", "Roles", "User_" + userId, "party_" + resourcePartyId, "roles.json");
+    }
+
+    private async Task<XacmlPolicy> GetPolicyAsync(XacmlContextRequest request)
+    {
+        XacmlPolicy xacmlPolicy = ParsePolicy("policy.xml", GetPolicyPath(request));
+        return await Task.FromResult(xacmlPolicy);
+    }
+
+    private string GetPolicyPath(XacmlContextRequest request)
+    {
+        string org = string.Empty;
+        string app = string.Empty;
+        foreach (XacmlContextAttributes attr in request.Attributes)
+        {
+            if (attr.Category.OriginalString.Equals(XacmlConstants.MatchAttributeCategory.Resource))
+            {
+                foreach (XacmlAttribute asd in attr.Attributes)
+                {
+                    if (asd.AttributeId.OriginalString.Equals(orgAttributeId))
+                    {
+                        foreach (var asff in asd.AttributeValues)
+                        {
+                            org = asff.Value;
+                            break;
+                        }
+                    }
+
+                    if (asd.AttributeId.OriginalString.Equals(appAttributeId))
+                    {
+                        foreach (var asff in asd.AttributeValues)
+                        {
+                            app = asff.Value;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return GetAltinnAppsPolicyPath(org, app);
+    }
+
+    public static XacmlPolicy ParsePolicy(string policyDocumentTitle, string policyPath)
+    {
+        XmlDocument policyDocument = new XmlDocument();
+        policyDocument.Load(Path.Combine(policyPath, policyDocumentTitle));
+        XacmlPolicy policy;
+        using (XmlReader reader = XmlReader.Create(new StringReader(policyDocument.OuterXml)))
+        {
+            policy = XacmlParser.ParseXacmlPolicy(reader);
+        }
+
+        return policy;
+    }
+
+    private static string GetAltinnAppsPolicyPath(string org, string app)
+    {
+        string unitTestFolder = Path.GetDirectoryName(new Uri(typeof(PepWithPDPAuthorizationMockSI).Assembly.Location).LocalPath);
+        return Path.Combine(unitTestFolder, "..", "..", "..", "Data", "apps", org, app, "config", "authorization");
+    }              
 }

--- a/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
@@ -111,23 +111,9 @@ public class AuthorizationServiceTest
     }
 
     [Fact]
-    public async Task AuthorizeConsumerForAltinnAppEvent_EventPublishedByApp_HandleUnsupportedSubject()
+    public async Task AuthorizeConsumerForAltinnAppEvent_EventPublishedByApp()
     {
         PepWithPDPAuthorizationMockSI pdp = new PepWithPDPAuthorizationMockSI();
-
-        _registerServiceMock.Setup(r => r.PartyLookup(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-            .Callback((IEnumerable<string> requestedUrnList, CancellationToken cancellationToken) =>
-            {
-                Assert.Single(requestedUrnList);
-                Assert.Equal("urn:altinn:person:identifier-no:11913049472", requestedUrnList.ElementAt(0));
-            })
-            .ReturnsAsync([new PartyIdentifiers
-            {
-                PartyId = 50301578,
-                PartyType = "person",
-                PersonIdentifier = "11913049472"
-            }
-            ]);
 
         CloudEvent cloudEvent = new()
         {
@@ -145,6 +131,80 @@ public class AuthorizationServiceTest
         // Assert
         Assert.Single(result);
         Assert.True(result["/user/1337"]);
+    }
+
+    [Fact]
+    public async Task AuthorizeConsumerForAltinnAppEvent_EventPublishedByDialogporten_HandleUnsupportedSubject()
+    {
+        Mock<IPDP> pdpMock = new();
+        pdpMock
+            .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), TestContext.Current.CancellationToken))
+            .Callback((XacmlJsonRequestRoot authRequest, CancellationToken cancellationToken) =>
+            {
+                List<XacmlJsonCategory> resources = authRequest.Request.Resource;
+                Assert.Single(resources);
+                Assert.Equal(4, resources[0].Attribute.Count); // Normally 5 attributes, but the instance id is missing for dialogporten events.
+            })
+            .ReturnsAsync(new XacmlJsonResponse
+            {
+                Response =
+                [
+                    new XacmlJsonResult
+                    {
+                        Decision = "Permit",
+                        Category =
+                        [
+                            new XacmlJsonCategory
+                            {
+                                CategoryId = XacmlConstants.MatchAttributeCategory.Subject,
+                                Attribute =
+                                [
+                                    new XacmlJsonAttribute
+                                    {
+                                        AttributeId = "urn:altinn:userid",
+                                        Value = "1337"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            });
+
+        _registerServiceMock.Setup(r => r.PartyLookup(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Callback((IEnumerable<string> requestedUrnList, CancellationToken cancellationToken) =>
+            {
+                Assert.Single(requestedUrnList);
+                Assert.Equal("urn:altinn:person:identifier-no:11913049472", requestedUrnList.ElementAt(0));
+            })
+            .ReturnsAsync([new PartyIdentifiers
+            {
+                PartyId = 50301578,
+                PartyType = "person",
+                PersonIdentifier = "11913049472",
+                PartyUuid = Guid.Parse("4a80af94-14be-4af5-9f95-a6a0824c5b55")
+            }
+            ]);
+
+        CloudEvent cloudEvent = new()
+        {
+            Source = new Uri("https://platform.altinn.no/dialogporten/api/v1/enduser/dialogs/321e249a-60a4-78de-9957-ae631b24e23f"),
+            Type = "dialogporten.dialog.created.v1",
+            Subject = "urn:altinn:person:identifier-no:11913049472"
+        };
+        cloudEvent["resource"] = "urn:altinn:resource:app_ttd_endring-av-navn-v2";
+
+        AuthorizationService authzHelper =
+            new(pdpMock.Object, _principalMock.Object, _registerServiceMock.Object, NullLogger<AuthorizationService>.Instance);
+
+        // Act
+        var result = await authzHelper.AuthorizeMultipleConsumersForAltinnAppEvent(cloudEvent, ["/user/1337"], TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(result);
+        Assert.True(result["/user/1337"]);
+
+        _registerServiceMock.VerifyAll();
     }
 
     [Fact]

--- a/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
@@ -111,6 +111,43 @@ public class AuthorizationServiceTest
     }
 
     [Fact]
+    public async Task AuthorizeConsumerForAltinnAppEvent_EventPublishedByApp_HandleUnsupportedSubject()
+    {
+        PepWithPDPAuthorizationMockSI pdp = new PepWithPDPAuthorizationMockSI();
+
+        _registerServiceMock.Setup(r => r.PartyLookup(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Callback((IEnumerable<string> requestedUrnList, CancellationToken cancellationToken) =>
+            {
+                Assert.Single(requestedUrnList);
+                Assert.Equal("urn:altinn:person:identifier-no:11913049472", requestedUrnList.ElementAt(0));
+            })
+            .ReturnsAsync([new PartyIdentifiers
+            {
+                PartyId = 50301578,
+                PartyType = "person",
+                PersonIdentifier = "11913049472"
+            }
+            ]);
+
+        CloudEvent cloudEvent = new()
+        {
+            Source = new Uri("https://ttd.apps.altinn.no/ttd/endring-av-navn-v2/instances/50301578/6fb3f738-6800-4f29-9f3e-1c66862656cd"),
+            Type = "app.instance.created",
+            Subject = "/party/50301578"
+        };
+
+        AuthorizationService authzHelper =
+            new(pdp, _principalMock.Object, _registerServiceMock.Object, NullLogger<AuthorizationService>.Instance);
+
+        // Act
+        var result = await authzHelper.AuthorizeMultipleConsumersForAltinnAppEvent(cloudEvent, ["/user/1337"], TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(result);
+        Assert.True(result["/user/1337"]);
+    }
+
+    [Fact]
     public async Task AuthorizeConsumerForGenericEvent_PdpIsCalledWithXacmlRequestRoot()
     {
         // Arrange
@@ -500,7 +537,7 @@ public class AuthorizationServiceTest
         // Arrange
         Mock<IPDP> pdpMock = new();
         pdpMock
-            .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+            .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new XacmlJsonResponse
             {
                 Response =
@@ -544,7 +581,7 @@ public class AuthorizationServiceTest
         // Arrange
         Mock<IPDP> pdpMock = new();
         pdpMock
-            .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+            .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new XacmlJsonResponse
             {
                 Response =
@@ -589,7 +626,7 @@ public class AuthorizationServiceTest
         var systemUserUuid = Guid.NewGuid().ToString();
         Mock<IPDP> pdpMock = new();
         pdpMock
-            .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+            .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new XacmlJsonResponse
             {
                 Response =
@@ -633,7 +670,7 @@ public class AuthorizationServiceTest
         // Arrange
         Mock<IPDP> pdpMock = new();
         pdpMock
-            .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+            .Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new XacmlJsonResponse
             {
                 Response =

--- a/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/AuthorizationServiceTest.cs
@@ -38,7 +38,7 @@ public class AuthorizationServiceTest
         _cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0)
         {
             Id = Guid.NewGuid().ToString(),
-            Type = "system.event.occurred",
+            Type = "app.instance.created",
             Subject = "/party/1337",
             Source = new Uri("https://ttd.apps.altinn.no/ttd/endring-av-navn-v2/instances/1337/6fb3f738-6800-4f29-9f3e-1c66862656cd")
         };
@@ -60,7 +60,7 @@ public class AuthorizationServiceTest
             new(pdp, _principalMock.Object, _registerServiceMock.Object, NullLogger<AuthorizationService>.Instance);
 
         // Act
-        var result = await authzHelper.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/user/1337"]);
+        var result = await authzHelper.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/user/1337"], TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -78,7 +78,7 @@ public class AuthorizationServiceTest
             new AuthorizationService(pdp, _principalMock.Object, _registerServiceMock.Object, NullLogger<AuthorizationService>.Instance);
 
         // Act
-        var result = await authzHelper.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/org/ttd"]);
+        var result = await authzHelper.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/org/ttd"], TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -97,12 +97,13 @@ public class AuthorizationServiceTest
 
         CloudEvent cloudEvent = new()
         {
-            Source = new Uri("https://skd.apps.altinn.no/ttd/endring-av-navn-v2/instances/1337/6fb3f738-6800-4f29-9f3e-1c66862656cd"),
+            Source = new Uri("https://ttd.apps.altinn.no/ttd/endring-av-navn-v2/instances/1337/6fb3f738-6800-4f29-9f3e-1c66862656cd"),
+            Type = "app.instance.created",
             Subject = "/party/1337"
         };
 
         // Act
-        var result = await authzHelper.AuthorizeMultipleConsumersForAltinnAppEvent(cloudEvent, ["/org/nav"]);
+        var result = await authzHelper.AuthorizeMultipleConsumersForAltinnAppEvent(cloudEvent, ["/org/nav"], TestContext.Current.CancellationToken);
 
         // Assert.
         Assert.Single(result);
@@ -529,7 +530,7 @@ public class AuthorizationServiceTest
         var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object, _registerServiceMock.Object, NullLogger<AuthorizationService>.Instance);
 
         // Act
-        var result = await sut.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/org/ttd"]);
+        var result = await sut.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/org/ttd"], TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -573,7 +574,7 @@ public class AuthorizationServiceTest
         var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object, _registerServiceMock.Object, NullLogger<AuthorizationService>.Instance);
 
         // Act
-        var result = await sut.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/user/12345"]);
+        var result = await sut.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/user/12345"], TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -618,7 +619,7 @@ public class AuthorizationServiceTest
         var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object, _registerServiceMock.Object, NullLogger<AuthorizationService>.Instance);
 
         // Act
-        var result = await sut.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, [$"/systemuser/{systemUserUuid}"]);
+        var result = await sut.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, [$"/systemuser/{systemUserUuid}"], TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -700,7 +701,7 @@ public class AuthorizationServiceTest
         var sut = new AuthorizationService(pdpMock.Object, _principalMock.Object, _registerServiceMock.Object, NullLogger<AuthorizationService>.Instance);
 
         // Act
-        var result = await sut.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/org/ttd", "/org/nav", "/user/12345678"]);
+        var result = await sut.AuthorizeMultipleConsumersForAltinnAppEvent(_cloudEvent, ["/org/ttd", "/org/nav", "/user/12345678"], TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(3, result.Count);

--- a/test/Altinn.Platform.Events.Tests/TestingServices/OutboundServiceTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/OutboundServiceTests.cs
@@ -341,8 +341,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             
             queueMock.Verify(
                 r => r.EnqueueOutbound(It.IsAny<string>()), 
-                Times.Exactly(4),
-                "Should enqueue 4 times - one for each subscription");
+                Times.Exactly(3),
+                "Should enqueue 3 times - one for each subscription, the forth subscription is filtered out due to source mismatch");
         }
 
         /// <summary>
@@ -1404,8 +1404,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
                 m => m.PublishAsync(
                     It.IsAny<Contracts.OutboundEventCommand>(),
                     It.IsAny<DeliveryOptions>()),
-                Times.Exactly(3),
-                "MessageBus should be called 3 times - for authorized subscriptions (2 for /org/ttd, 1 for /user/1337)");
+                Times.Exactly(2),
+                "MessageBus should be called 2 times - for authorized subscriptions (1 for /org/ttd, 1 for /user/1337), 0 for /org/nav");
 
             queueMock.Verify(
                 q => q.EnqueueOutbound(It.IsAny<string>()),

--- a/test/Altinn.Platform.Events.Tests/TestingServices/OutboundServiceTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingServices/OutboundServiceTests.cs
@@ -24,12 +24,16 @@ using Altinn.Platform.Events.UnitTest.Mocks;
 
 using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.SystemTextJson;
+
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+
 using Moq;
+
 using Wolverine;
+
 using Xunit;
 
 namespace Altinn.Platform.Events.Tests.TestingServices
@@ -48,7 +52,11 @@ namespace Altinn.Platform.Events.Tests.TestingServices
         public async Task PostOutbound_AppEvent_SourceFilterIsSimplified()
         {
             // Arrange
-            CloudEvent cloudEvent = GetCloudEvent(new Uri("https://ttd.apps.altinn.no/ttd/endring-av-navn-v2/instances/1337/123124"), "/party/1337/", "app.instance.process.completed", "urn:altinn:resource:app_ttd_endring-av-navn-v2");
+            CloudEvent cloudEvent = GetCloudEvent(
+                new Uri("https://ttd.apps.altinn.no/ttd/endring-av-navn-v2/instances/1337/01f66e22-33bb-4b14-8059-f2d7a8d16dc8"),
+                "/party/1337", 
+                "app.instance.process.completed", 
+                "urn:altinn:resource:app_ttd_endring-av-navn-v2");
 
             Mock<ISubscriptionRepository> repositoryMock = new();
             repositoryMock
@@ -92,7 +100,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
             Mock<IAuthorization> authorizationMock = new();
             authorizationMock
-                .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(It.IsAny<CloudEvent>(), It.IsAny<List<string>>()))
+                .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(It.IsAny<CloudEvent>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync([]);
             Mock<IEventsQueueClient> queueMock = new();
             queueMock
@@ -105,7 +113,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
             // Assert
             repositoryMock.VerifyAll();
-            authorizationMock.Verify(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(It.IsAny<CloudEvent>(), It.IsAny<List<string>>()), Times.Never);
+            authorizationMock.Verify(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(It.IsAny<CloudEvent>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()), Times.Never);
             queueMock.Verify(r => r.EnqueueOutbound(It.IsAny<string>()), Times.Never);
         }
 
@@ -252,7 +260,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authorizationMock
                 .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.IsAny<List<string>>()))
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Dictionary<string, bool> { { "/org/nav", false } });
 
             var service = GetOutboundService(
@@ -268,7 +277,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authorizationMock.Verify(
                 a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.Is<List<string>>(list => list.Contains("/org/nav"))),
+                    It.Is<List<string>>(list => list.Contains("/org/nav")),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
             queueMock.Verify(r => r.EnqueueOutbound(It.IsAny<string>()), Times.Never);
         }
@@ -303,12 +313,13 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authorizationMock
                 .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(), 
-                    It.IsAny<List<string>>()))
-                .Callback<CloudEvent, List<string>>((ce, consumers) => 
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<CloudEvent, List<string>, CancellationToken>((ce, consumers, ct) => 
                 {
                     capturedConsumers = consumers;
                 })
-                .ReturnsAsync((CloudEvent ce, List<string> consumers) =>
+                .ReturnsAsync((CloudEvent ce, List<string> consumers, CancellationToken ct) =>
                 {
                     // Return true for all consumers that were passed in
                     var results = new Dictionary<string, bool>();
@@ -329,7 +340,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authorizationMock.Verify(
                 a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(), 
-                    It.IsAny<List<string>>()), 
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Once,
                 "Authorization should be called once with distinct consumers");
             
@@ -342,7 +354,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             queueMock.Verify(
                 r => r.EnqueueOutbound(It.IsAny<string>()), 
                 Times.Exactly(3),
-                "Should enqueue 3 times - one for each subscription, the forth subscription is filtered out due to source mismatch");
+                "Should enqueue 3 times, the forth subscription is filtered out due to source mismatch");
         }
 
         /// <summary>
@@ -365,7 +377,7 @@ namespace Altinn.Platform.Events.Tests.TestingServices
 
             Mock<IAuthorization> authorizationMock = new();
             authorizationMock
-                .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(It.IsAny<CloudEvent>(), It.IsAny<List<string>>()))
+                .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(It.IsAny<CloudEvent>(), It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Dictionary<string, bool>
                 {
                     { "/user/1337", true }
@@ -429,8 +441,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authorizationMock
                 .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.IsAny<List<string>>()))
-                .ReturnsAsync((CloudEvent ce, List<string> consumers) =>
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CloudEvent ce, List<string> consumers, CancellationToken ct) =>
                 {
                     // Return true for all consumers
                     var results = new Dictionary<string, bool>();
@@ -1002,7 +1015,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authMock
                 .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.Is<List<string>>(list => list.Contains(consumer))))
+                    It.Is<List<string>>(list => list.Contains(consumer)),
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Dictionary<string, bool> { { consumer, true } });
 
             Mock<IEventsQueueClient> queueMock = new();
@@ -1024,7 +1038,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authMock.Verify(
                 a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.IsAny<List<string>>()),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
 
             Assert.True(cache.TryGetValue(expectedCacheKey, out bool cachedValue));
@@ -1078,7 +1093,8 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authMock.Verify(
                 a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.IsAny<List<string>>()),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Never);
         }
 
@@ -1266,8 +1282,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authorizationMock
                 .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.IsAny<List<string>>()))
-                .ReturnsAsync((CloudEvent ce, List<string> consumers) =>
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CloudEvent ce, List<string> consumers, CancellationToken ct) =>
                 {
                     var results = new Dictionary<string, bool>();
                     foreach (var consumer in consumers)
@@ -1322,8 +1339,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authorizationMock
                 .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.IsAny<List<string>>()))
-                .ReturnsAsync((CloudEvent ce, List<string> consumers) =>
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CloudEvent ce, List<string> consumers, CancellationToken ct) =>
                 {
                     var results = new Dictionary<string, bool>();
                     foreach (var consumer in consumers)
@@ -1378,8 +1396,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authorizationMock
                 .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.IsAny<List<string>>()))
-                .ReturnsAsync((CloudEvent ce, List<string> consumers) =>
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CloudEvent ce, List<string> consumers, CancellationToken ct) =>
                 {
                     // Authorize only /org/ttd and /user/1337, not /org/nav
                     var results = new Dictionary<string, bool>
@@ -1438,8 +1457,9 @@ namespace Altinn.Platform.Events.Tests.TestingServices
             authorizationMock
                 .Setup(a => a.AuthorizeMultipleConsumersForAltinnAppEvent(
                     It.IsAny<CloudEvent>(),
-                    It.IsAny<List<string>>()))
-                .ReturnsAsync((CloudEvent ce, List<string> consumers) =>
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CloudEvent ce, List<string> consumers, CancellationToken ct) =>
                 {
                     var results = new Dictionary<string, bool>();
                     foreach (var consumer in consumers)

--- a/test/Altinn.Platform.Events.Tests/TestingUtils/AppCloudEventXacmlMapperTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingUtils/AppCloudEventXacmlMapperTests.cs
@@ -106,6 +106,7 @@ public class AppCloudEventXacmlMapperTests
         CloudEvent cloudEvent = new()
         {
             Source = new Uri("https://skd.apps.altinn.no/skd/skattemelding/instances/1234324/6fb3f738-6800-4f29-9f3e-1c66862656cd"),
+            Type = "app.instance.created",
             Subject = "/party/1234324"
         };
         
@@ -116,6 +117,31 @@ public class AppCloudEventXacmlMapperTests
         Assert.NotNull(xacmlJsonProfile);
         Assert.Single(xacmlJsonProfile.Request.Action);
         Assert.Single(xacmlJsonProfile.Request.Resource);
+        Assert.Equal(5, xacmlJsonProfile.Request.Resource[0].Attribute.Count);
+        Assert.Equal(3, xacmlJsonProfile.Request.AccessSubject.Count);
+    }
+
+    [Fact]
+    public void CreateMultiDecisionRequest_DialogportenEvent_ShouldReturnValidXACMLRequest_ForMultipleConsumers()
+    {
+        // Arrange
+        List<string> consumers = ["/org/a", "/org/b", "/org/c"];
+        CloudEvent cloudEvent = new()
+        {
+            Source = new Uri("https://platform.altinn.no/dialogporten/api/v1/enduser/dialogs/321e249a-60a4-78de-9957-ae631b24e23f"),
+            Type = "dialogporten.dialog.created.v1",
+            Subject = "urn:altinn:organization:identifier-no:312508729"
+        };
+        cloudEvent["resource"] = "urn:altinn:resource:app_ssb_ra1000-02";
+
+        // Act
+        XacmlJsonRequestRoot xacmlJsonProfile = AppCloudEventXacmlMapper.CreateMultiDecisionRequestForMultipleConsumers(cloudEvent, consumers);
+
+        // Assert.
+        Assert.NotNull(xacmlJsonProfile);
+        Assert.Single(xacmlJsonProfile.Request.Action);
+        Assert.Single(xacmlJsonProfile.Request.Resource);
+        Assert.Equal(4, xacmlJsonProfile.Request.Resource[0].Attribute.Count); // Missing instanceId
         Assert.Equal(3, xacmlJsonProfile.Request.AccessSubject.Count);
     }
 

--- a/test/bruno/Events/Events Outbound/App published event (nin).bru
+++ b/test/bruno/Events/Events Outbound/App published event (nin).bru
@@ -1,0 +1,34 @@
+meta {
+  name: App published event (nin)
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{PlatformHostUrl}}/events/api/v1/outbound
+  body: json
+  auth: inherit
+}
+
+headers {
+  Content-Type: application/cloudevents+json
+}
+
+body:json {
+  {
+    "specversion": "1.0",
+    "id": "9611d8c2-b1b2-4491-9133-b21680a7cbc4",
+    "time": "2022-11-15T10:46:53.5339928Z",
+    "type": "app.instance.created",
+    "source": "https://ttd.apps.at23.altinn.cloud/ttd/apps-test/instances/51326198/428a4575-2c04-4400-89a3-1aaadd2579cd",
+    "resource": "urn:altinn:resource:app_ttd_apps-test",
+    "resourceinstance": "50660768/428a4575-2c04-4400-89a3-1aaadd2579cd",
+    "subject": "/party/50660768",
+    "alternativesubject": "/person/07837399275"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/test/bruno/Events/Events Outbound/App published event (nin).bru
+++ b/test/bruno/Events/Events Outbound/App published event (nin).bru
@@ -20,7 +20,7 @@ body:json {
     "id": "9611d8c2-b1b2-4491-9133-b21680a7cbc4",
     "time": "2022-11-15T10:46:53.5339928Z",
     "type": "app.instance.created",
-    "source": "https://ttd.apps.at23.altinn.cloud/ttd/apps-test/instances/51326198/428a4575-2c04-4400-89a3-1aaadd2579cd",
+    "source": "https://ttd.apps.at23.altinn.cloud/ttd/apps-test/instances/50660768/428a4575-2c04-4400-89a3-1aaadd2579cd",
     "resource": "urn:altinn:resource:app_ttd_apps-test",
     "resourceinstance": "50660768/428a4575-2c04-4400-89a3-1aaadd2579cd",
     "subject": "/party/50660768",

--- a/test/bruno/Events/Events Outbound/Dialogporten published event (nin).bru
+++ b/test/bruno/Events/Events Outbound/Dialogporten published event (nin).bru
@@ -1,0 +1,33 @@
+meta {
+  name: Dialogporten published event (nin)
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{PlatformHostUrl}}/events/api/v1/outbound
+  body: json
+  auth: inherit
+}
+
+headers {
+  Content-Type: application/cloudevents+json
+}
+
+body:json {
+  {
+    "specversion": "1.0",
+    "id": "9611d8c2-b1b2-4491-9133-b21680a7cbc4",
+    "time": "2022-11-15T10:46:53.5339928Z",
+    "type": "dialogporten.dialog.created.v1",
+    "source": "https://platform.at23.altinn.cloud/dialogporten/api/v1/enduser/dialogs/019ea49a-60a4-78de-9957-ae626abacd3f",
+    "resource": "urn:altinn:resource:app_ttd_apps-test",
+    "resourceinstance": "019ea49a-60a4-78de-9957-ae626abacd3f",
+    "subject": "urn:altinn:person:identifier-no:07837399275"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/tools/testdata/outbound-subscriptions.sql
+++ b/tools/testdata/outbound-subscriptions.sql
@@ -27,3 +27,9 @@ SELECT events.insert_subscription_v2('urn:altinn:resource:app_ttd_other-app',   
 SELECT events.insert_subscription_v2('urn:altinn:resource:app_ttd_apps-test',    NULL, '/party/53326193',                                 NULL,  '/org/nav',   'https://webhook.example.com/nav-wrong-type',  '/org/nav',   true,  false);
 SELECT events.insert_subscription_v2('urn:altinn:resource:nabovarsel',           NULL, 'urn:altinn:organization:identifier-no:324259572', NULL,  '/org/nav',   'https://webhook.example.com/nav-unvalidated', '/org/nav',   false, false);
 SELECT events.insert_subscription_v2('urn:altinn:resource:some_other_resource',  NULL, 'urn:altinn:organization:identifier-no:313133745', NULL,  '/org/other', 'https://webhook.example.com/other',           '/org/other', true,  false);
+
+-- Subscriptions for testing of source filtering.
+SELECT events.insert_subscription_v2('urn:altinn:resource:app_ttd_apps-test',  'https://ttd.apps.at23.altinn.cloud/ttd/apps-test',                       NULL, NULL,  '/org/ttd', 'https://webhook.example.com/ttd', '/org/ttd', true,  false);
+SELECT events.insert_subscription_v2('urn:altinn:resource:app_ttd_apps-test',  NULL,                                                                     NULL, NULL,  '/org/ttd', 'https://webhook.example.com/ttd', '/org/ttd', true,  false);
+SELECT events.insert_subscription_v2('urn:altinn:resource:app_ttd_apps-test',  'https://platform.at23.altinn.cloud/dialogporten/api/v1/enduser/dialogs', NULL, NULL,  '/org/ttd', 'https://webhook.example.com/ttd', '/org/ttd', true,  false);
+


### PR DESCRIPTION
## Description
Fixing an issue with Events being unable to authorize access to app events published by Dialogporten.

## Related Issue(s)
- #930 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced source filtering capabilities for event subscriptions
  * Improved authorization request handling with cancellation token support
  * Better resource attribute mapping for app-published and external events

* **Tests**
  * Expanded test coverage for authorization scenarios and event handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->