### PR TITLE
Remove 'pinDigests' from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,8 +29,7 @@
       "matchStrings": [
         "\"(?<depName>[^:\"]+):(?<currentValue>[^@\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\""
       ],
-      "datasourceTemplate": "docker",
-      "pinDigests": true
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
Removed the 'pinDigests' property from the configuration.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
-  https://github.com/Altinn/team-core-private/issues/495

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management settings so certain container image references are no longer pinned to exact digests, allowing them to track newer Docker images more flexibly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->