### PR TITLE
Revert "Update dependency WolverineFx.AzureServiceBus to v6 (#1031)"

### DIFF
--- a/src/Events/Altinn.Platform.Events.csproj
+++ b/src/Events/Altinn.Platform.Events.csproj
@@ -26,9 +26,8 @@
 		<PackageReference Include="Scrutor" Version="7.0.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.2" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.2" />
-		<PackageReference Include="WolverineFx" Version="6.14.0" />
-		<PackageReference Include="WolverineFx.AzureServiceBus" Version="6.14.0" />
-		<PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
+		<PackageReference Include="WolverineFx" Version="5.39.5" />
+		<PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.5" />
 		<PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
 		<PackageReference Include="Yuniql.PostgreSql" Version="1.3.15" />
 	</ItemGroup>


### PR DESCRIPTION
This reverts commit 7779ca57f30e1bf2c023a152da1540189e9dfae9.

Seems to be an issue with getting subscriptions, https://github.com/Altinn/altinn-events/actions/workflows/use-case-ATX.yaml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal messaging dependencies to earlier stable versions.
  * Removed an unused runtime compilation dependency to keep the build leaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->