### PR TITLE
Bug/977 validate source filter scheme to be https

### DIFF
--- a/src/Events/Controllers/SubscriptionController.cs
+++ b/src/Events/Controllers/SubscriptionController.cs
@@ -61,12 +61,12 @@ namespace Altinn.Platform.Events.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<Subscription>> Post([FromBody] SubscriptionRequestModel subscriptionRequest)
         {
-            if (subscriptionRequest.EndPoint == null || !(subscriptionRequest.EndPoint.IsAbsoluteUri && subscriptionRequest.EndPoint.Scheme == Uri.UriSchemeHttps))
+            if (!IsValidUri(subscriptionRequest.EndPoint))
             {
                 return StatusCode(400, "Missing or invalid endpoint to push events towards");
             }
 
-            if (subscriptionRequest.SourceFilter != null && !(subscriptionRequest.SourceFilter.IsAbsoluteUri && subscriptionRequest.SourceFilter.Scheme == Uri.UriSchemeHttps))
+            if (subscriptionRequest.SourceFilter is not null && !IsValidUri(subscriptionRequest.SourceFilter))
             {
                 return StatusCode(400, "SourceFilter must be an absolute URL with the https scheme.");
             }
@@ -188,6 +188,16 @@ namespace Altinn.Platform.Events.Controllers
             return Ok();
         }
 
+        private static bool IsValidUri(Uri uri)
+        {
+            return uri is not null && uri.IsAbsoluteUri && uri.Scheme == Uri.UriSchemeHttps;
+        }
+
+        private static void AddQueryModelToTelemetry(SubscriptionRequestModel subscriptionRequest)
+        {
+            Activity.Current?.AddTag("subscription.request", JsonSerializer.Serialize(subscriptionRequest));
+        }
+
         private bool IsAppSubscription(SubscriptionRequestModel subscription)
         {
             if (subscription.ResourceFilter != null &&
@@ -202,11 +212,6 @@ namespace Altinn.Platform.Events.Controllers
             }
 
             return false;
-        }
-
-        private static void AddQueryModelToTelemetry(SubscriptionRequestModel subscriptionRequest)
-        {
-            Activity.Current?.AddTag("subscription.request", JsonSerializer.Serialize(subscriptionRequest));
         }
     }
 }

--- a/src/Events/Controllers/SubscriptionController.cs
+++ b/src/Events/Controllers/SubscriptionController.cs
@@ -61,9 +61,9 @@ namespace Altinn.Platform.Events.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<Subscription>> Post([FromBody] SubscriptionRequestModel subscriptionRequest)
         {
-            if (subscriptionRequest.SourceFilter != null && !Uri.IsWellFormedUriString(subscriptionRequest.SourceFilter.ToString(), UriKind.Absolute))
+            if (subscriptionRequest.SourceFilter != null && !(subscriptionRequest.SourceFilter.IsAbsoluteUri && subscriptionRequest.SourceFilter.Scheme == Uri.UriSchemeHttps))
             {
-                return StatusCode(400, "SourceFilter must be an absolute URI");
+                return StatusCode(400, "SourceFilter must be an absolute URL with the https scheme.");
             }
 
             bool isAppSubscription = IsAppSubscription(subscriptionRequest);

--- a/src/Events/Controllers/SubscriptionController.cs
+++ b/src/Events/Controllers/SubscriptionController.cs
@@ -61,6 +61,11 @@ namespace Altinn.Platform.Events.Controllers
         [Produces("application/json")]
         public async Task<ActionResult<Subscription>> Post([FromBody] SubscriptionRequestModel subscriptionRequest)
         {
+            if (subscriptionRequest.EndPoint == null || !(subscriptionRequest.EndPoint.IsAbsoluteUri && subscriptionRequest.EndPoint.Scheme == Uri.UriSchemeHttps))
+            {
+                return StatusCode(400, "Missing or invalid endpoint to push events towards");
+            }
+
             if (subscriptionRequest.SourceFilter != null && !(subscriptionRequest.SourceFilter.IsAbsoluteUri && subscriptionRequest.SourceFilter.Scheme == Uri.UriSchemeHttps))
             {
                 return StatusCode(400, "SourceFilter must be an absolute URL with the https scheme.");
@@ -71,11 +76,6 @@ namespace Altinn.Platform.Events.Controllers
             if (!isAppSubscription && !User.HasRequiredScope(AuthorizationConstants.SCOPE_EVENTS_SUBSCRIBE))
             {
                 return Forbid();
-            }
-
-            if (subscriptionRequest.EndPoint == null || !Uri.IsWellFormedUriString(subscriptionRequest.EndPoint.ToString(), UriKind.Absolute))
-            {
-                return StatusCode(400, "Missing or invalid endpoint to push events towards");
             }
 
             if (subscriptionRequest.ResourceFilter != null && !UriExtensions.IsValidUrn(subscriptionRequest.ResourceFilter))

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
@@ -339,7 +339,6 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             /// </summary>
             [Theory]
             [InlineData("skd/flyttemelding")]
-            [InlineData("skd\\flyttemelding")]
             [InlineData("altinn.no/ttd/apps-test/")]
             [InlineData("platform.altinn.no/")]
             [InlineData("http://altinn.no/ttd/")]
@@ -370,15 +369,45 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             }
 
             /// <summary>
+            /// Post a subscription without an endpoint.
+            /// Expected result: Returns HttpStatus badrequest
+            /// Success criteria: The response has correct status and expected response message.
+            /// </summary>
+            [Fact]
+            public async Task Post_GivenSubscriptionWithoutEndpoint_ReturnsBadRequest()
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/subscriptions";
+
+                SubscriptionRequestModel cloudEventSubscription = GetEventsSubscriptionRequest(
+                    "https://skd.apps.altinn.no/skd/flyttemelding", null, subjectFilter: "/party/133");
+
+                HttpClient client = GetTestClient();
+
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", "950474084"));
+
+                HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri)
+                {
+                    Content = new StringContent(cloudEventSubscription.Serialize(), Encoding.UTF8, "application/json")
+                };
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+                string responseMessage = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                Assert.Equal("\"Missing or invalid endpoint to push events towards\"", responseMessage);
+            }
+
+            /// <summary>
             /// Scenario: Attempting to create a subscription with an invalid source filter value.
             /// Expected: Returns bad request and appropriate error message.
             /// Source filter isn't required so we're not testing for null or empty string.
             /// </summary>
             [Theory]
-            [InlineData(null)]
             [InlineData("")]
             [InlineData("skd/flyttemelding")]
-            [InlineData("skd\\flyttemelding")]
             [InlineData("altinn.no/ttd/apps-test/")]
             [InlineData("platform.altinn.no/")]
             [InlineData("http://altinn.no/ttd/")]

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
@@ -228,7 +228,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             }
 
             [Fact]
-            public async Task ValidateSubscription_ReturnsOk()
+            public async Task Validate_ValidSubscription_ReturnsOk()
             {
                 // Arrange
                 string requestUri = $"{BasePath}/subscriptions/validate/16";
@@ -365,21 +365,29 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             }
 
             /// <summary>
-            /// Scenario: Invalid source provided relative URI, absolute requied
-            /// Expected: Returns bad request
+            /// Scenario: Attempting to create a subscription with an invalid source filter value.
+            /// Expected: Returns bad request and appropriate error message.
+            /// Source filter isn't required so we're not testing for null or empty string.
             /// </summary>
-            [Fact]
-            public async Task Post_GivenSubscriptionWithRelativeUriSource_ReturnsBadRequest()
+            [Theory]
+            [InlineData("skd/flyttemelding")]
+            [InlineData("skd\\flyttemelding")]
+            [InlineData("altinn.no/ttd/apps-test/")]
+            [InlineData("platform.altinn.no/")]
+            [InlineData("http://altinn.no/ttd/")]
+            [InlineData("sftp://altinn.no/ttd/")]
+            public async Task Post_SourceFilterIsNotAnAbsoluteHttpsUrl_ReturnsBadRequest(string source)
             {
                 // Arrange
                 string requestUri = $"{BasePath}/subscriptions";
-                SubscriptionRequestModel cloudEventSubscription = GetEventsSubscriptionRequest("skd/flyttemelding", "https://www.skatteetaten.no/hook");
+                string subscription = "{ \"sourceFilter\": \"" + source + "\", \"endPoint\": \"https://www.skatteetaten.no/hook\" }";
 
                 HttpClient client = GetTestClient();
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("skd"));
-                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
+                
+                HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri)
                 {
-                    Content = new StringContent(cloudEventSubscription.Serialize(), Encoding.UTF8, "application/json")
+                    Content = new StringContent(subscription, Encoding.UTF8, "application/json")
                 };
 
                 // Act
@@ -387,6 +395,10 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
 
                 // Assert
                 Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                
+                // Check that the bad request respons is actually about the source filter and not an other property.
+                string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+                Assert.Equal("\"SourceFilter must be an absolute URL with the https scheme.\"", responseContent);
             }
 
             /// <summary>

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
@@ -401,9 +401,12 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             }
 
             /// <summary>
-            /// Scenario: Attempting to create a subscription with an invalid source filter value.
-            /// Expected: Returns bad request and appropriate error message.
-            /// Source filter isn't required so we're not testing for null or empty string.
+            /// Scenario: 
+            ///     Attempting to create a subscription with an invalid endpoint value.
+            /// Expected: 
+            ///     Returns response code 400 - Bad Request and specific error message.
+            /// Success criteria:
+            ///     The response has correct status and expected response message.
             /// </summary>
             [Theory]
             [InlineData("")]

--- a/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
+++ b/test/Altinn.Platform.Events.Tests/TestingControllers/SubscriptionControllerTests.cs
@@ -301,38 +301,6 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             }
 
             /// <summary>
-            /// Post invalid subscription for org with missing endpoint
-            /// Expected result:
-            /// Returns HttpStatus badrequest
-            /// Success criteria:
-            /// The response has correct status and expected response message.
-            /// </summary>
-            [Fact]
-            public async Task Post_GivenSubscriptionWithoutEndpoint_ReturnsBadRequest()
-            {
-                // Arrange
-                string requestUri = $"{BasePath}/subscriptions";
-                SubscriptionRequestModel cloudEventSubscription = GetEventsSubscriptionRequest("https://skd.apps.altinn.no/skd/flyttemelding", null, subjectFilter: "/party/133");
-
-                cloudEventSubscription.EndPoint = null;
-
-                HttpClient client = GetTestClient();
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", "950474084"));
-                HttpRequestMessage httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri)
-                {
-                    Content = new StringContent(cloudEventSubscription.Serialize(), Encoding.UTF8, "application/json")
-                };
-
-                // Act
-                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
-                string responseMessage = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-
-                // Assert
-                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-                Assert.Equal("\"Missing or invalid endpoint to push events towards\"", responseMessage);
-            }
-
-            /// <summary>
             /// Post invalid subscription with resource notfor user with persn as subject
             /// Expected result:
             /// Returns bad request 
@@ -380,7 +348,7 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
             {
                 // Arrange
                 string requestUri = $"{BasePath}/subscriptions";
-                string subscription = "{ \"sourceFilter\": \"" + source + "\", \"endPoint\": \"https://www.skatteetaten.no/hook\" }";
+                string subscription = "{ \"sourceFilter\": \"" + source + "\", \"endPoint\": \"https://altinn.no/hook\" }";
 
                 HttpClient client = GetTestClient();
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("skd"));
@@ -399,6 +367,45 @@ namespace Altinn.Platform.Events.Tests.TestingControllers
                 // Check that the bad request respons is actually about the source filter and not an other property.
                 string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
                 Assert.Equal("\"SourceFilter must be an absolute URL with the https scheme.\"", responseContent);
+            }
+
+            /// <summary>
+            /// Scenario: Attempting to create a subscription with an invalid source filter value.
+            /// Expected: Returns bad request and appropriate error message.
+            /// Source filter isn't required so we're not testing for null or empty string.
+            /// </summary>
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("skd/flyttemelding")]
+            [InlineData("skd\\flyttemelding")]
+            [InlineData("altinn.no/ttd/apps-test/")]
+            [InlineData("platform.altinn.no/")]
+            [InlineData("http://altinn.no/ttd/")]
+            [InlineData("sftp://altinn.no/ttd/")]
+            public async Task Post_EndPointIsNotAnAbsoluteHttpsUrl_ReturnsBadRequest(string endPoint)
+            {
+                // Arrange
+                string requestUri = $"{BasePath}/subscriptions";
+                string subscription = "{ \"endPoint\": \"" + endPoint + "\" }";
+
+                HttpClient client = GetTestClient();
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("skd"));
+
+                HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, requestUri)
+                {
+                    Content = new StringContent(subscription, Encoding.UTF8, "application/json")
+                };
+
+                // Act
+                HttpResponseMessage response = await client.SendAsync(httpRequestMessage, TestContext.Current.CancellationToken);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+                // Check that the bad request respons is actually about the end point and not an other property.
+                string responseContent = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+                Assert.Equal("\"Missing or invalid endpoint to push events towards\"", responseContent);
             }
 
             /// <summary>


### PR DESCRIPTION
## Description
Improve validation of both the source filter and endpoint addresses of a new subscription.

Both needs to be an absolute uri and the echeme must be https. EndPoint is required while source filter is optional.

## Related Issue(s)
- #977 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
- [ ] Manual testing done (required)

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription endpoints now require absolute HTTPS URLs.
  * Source filters now require absolute HTTPS URLs when provided.
  * Invalid resource filter values return clearer, exact validation messages.
  * Improved validation ordering for clearer 400 responses.

* **Tests**
  * Expanded negative validation coverage for subscriptions (endpoints, source filters, and resource filters).
  * Renamed and adjusted tests to match the stricter HTTPS URL rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->