### PR TITLE
Coderabbit should ignore migration version folders

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,3 @@
 reviews:
   path_filters:
-    - "!src/Events/Migration/**"
-    - "src/Events/Migration/FunctionsAndProcedures/**"
+    - "!src/Events/Migration/v*/**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,3 @@
 reviews:
   path_filters:
-    - "!src/Events/Migration/v*/**"
+    - "!src/Events/Migration/v*/*functions-and-procedures.sql"


### PR DESCRIPTION
## Description
Trying to have coderabbit look at files outside the src/Events/Migration/FunctionsAndProcedures folder. Just not the version folders.

## Related Issue(s)
- Reduce some unnecessary coderabbit work on generated files.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
