### PR TITLE
Add connection string changes for application insights

### DIFF
--- a/src/Events/Program.cs
+++ b/src/Events/Program.cs
@@ -336,14 +336,12 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
 
 void AddAzureMonitorTelemetryExporters(IServiceCollection services, IConfiguration config)
 {
-    var instrumentationKey = config.GetValue<string>("ApplicationInsights:InstrumentationKey");
+    var applicationInsightsConnectionString = config.GetValue<string>("ApplicationInsights:ConnectionString");
 
-    if (string.IsNullOrEmpty(instrumentationKey))
+    if (string.IsNullOrEmpty(applicationInsightsConnectionString))
     {
         return;
     }
-
-    var applicationInsightsConnectionString = string.Format("InstrumentationKey={0}", instrumentationKey);
 
     services.Configure<OpenTelemetryLoggerOptions>(logging => logging.AddAzureMonitorLogExporter(o =>
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1068 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Azure Monitor telemetry configuration to use the Application Insights connection string directly.
  * Telemetry exporters remain disabled when no connection string is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->